### PR TITLE
Maven warnings removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
 	<properties>
 		<jetty.version>7.3.0.v20110203</jetty.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
@@ -76,6 +77,7 @@
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>


### PR DESCRIPTION
This commit fixes a couple of Maven warnings:
- encoding set to UTF-8
- maven-compiler-plugin version set.
