### PR TITLE
Tests should not depend on execution order

### DIFF
--- a/src/test/java/spark/BooksIntegrationTest.java
+++ b/src/test/java/spark/BooksIntegrationTest.java
@@ -88,6 +88,9 @@ public class BooksIntegrationTest {
    @Test
    public void testGetBook() {
       try {
+		 // ensure there is a book
+		 testCreateBook();
+		 
          UrlResponse response = doMethod("GET", "/books/" + id, null);
          String result = response.body;
          Assert.assertNotNull(response);
@@ -99,6 +102,9 @@ public class BooksIntegrationTest {
          // verify response header set by filters:
          Assert.assertTrue(response.headers.get("FOZ").get(0).equals("BAZ"));
          Assert.assertTrue(response.headers.get("FOO").get(0).equals("BAR"));
+		 
+		 // delete the book again
+		 testDeleteBook();
       } catch (Throwable e) {
          throw new RuntimeException(e);
       }


### PR DESCRIPTION
running "mvn test" I see that at least on my installation the testGetBook() test of BooksIntegrationTest is run before testCreateBook(), which means that the "id" field is not yet set. Consequently, the test fails to GET "/books/null".

From what I understand it is not recommended to rely on the execution order of tests. The attached code fixes this in a somewhat crude way that involves only minimal changes.
