### PR TITLE
Java OutputStream 64kiB limit fix

### DIFF
--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -16,6 +16,7 @@
  */
 package spark.webserver;
 
+import java.io.OutputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -189,7 +190,11 @@ public class MatcherFilter implements Filter {
 
         if (consumed) {
             // Write body content
-            httpResponse.getOutputStream().write(bodyContent.getBytes("utf-8"));
+            final byte[] bodyBytes = bodyContent.getBytes("utf-8");
+            final OutputStream os = httpResponse.getOutputStream();
+            for (int start = 0; start < bodyBytes.length; start += 65536) {
+              os.write(bodyBytes, start, Math.min(65536, bodyBytes.length - start));
+            }
         } else if (chain != null) {
             chain.doFilter(httpRequest, httpResponse);
         }


### PR DESCRIPTION
Issue #40 is caused because [Java's `OutputStream`s can only handle a write of up to 64kiB at a time](http://www.drillio.com/en/software-development/java/encoded-string-too-long-64kb-limit/). Spark currently writes the entire web page at once, so if the page is larger than 64kiB, it gets truncated.

This fixes it by changing `spark.webserver.MatcherFilter` to write a 64kiB block at a time.
