### PR TITLE
FIX: Request.url() returns null when HTTP PUT request is made

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -160,7 +160,7 @@ public class Request {
      * Returns the URL string
      */
     public String url() {
-        return scheme() + "://" + host() + pathInfo();
+    	return servletRequest.getRequestURL().toString();
     }
     
     /**


### PR DESCRIPTION
...() and HttpServletRequest.getPathInfo() with a call to HttpServletRequest.getServletURL()

Calls to HttpServletRequest.getPathInfo() return null if extra path information is unavailable causing malformed URLs to be returned.
