### PR TITLE
Support for HTTP PATCH 

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -25,15 +25,15 @@ import spark.webserver.SparkServerFactory;
 /**
  * The main building block of a Spark application is a set of routes. A route is
  * made up of three simple pieces:
- * 
+ * <p/>
  * <ul>
  * <li>A verb (get, post, put, delete, head, trace, connect, options)</li>
  * <li>A path (/hello, /users/:name)</li>
  * <li>A callback ( handle(Request request, Response response) )</li>
  * </ul>
- * 
+ * <p/>
  * Example:
- * 
+ * <p/>
  * <pre>
  * {@code
  * Spark.get(new Route("/hello") {
@@ -42,11 +42,11 @@ import spark.webserver.SparkServerFactory;
  *    }
  * });
  * </pre>
- * 
+ * <p/>
  * <code>
-      
-   </code>
- * 
+ * <p/>
+ * </code>
+ *
  * @author Per Wendel
  */
 public final class Spark {
@@ -68,15 +68,15 @@ public final class Spark {
     private static String staticFileRoute = null;
 
     // Hide constructor
-    private Spark() {}
-    
+    private Spark() {
+    }
+
     /**
      * Set the IP address that Spark should listen on. If not called the default
      * address is '0.0.0.0'. This has to be called before any route mapping is
      * done.
-     * 
-     * @param ipAddress
-     *            The ipAddress
+     *
+     * @param ipAddress The ipAddress
      */
     public static synchronized void setIpAddress(String ipAddress) {
         if (initialized) {
@@ -88,9 +88,8 @@ public final class Spark {
     /**
      * Set the port that Spark should listen on. If not called the default port
      * is 4567. This has to be called before any route mapping is done.
-     * 
-     * @param port
-     *            The port number
+     *
+     * @param port The port number
      */
     public static synchronized void setPort(int port) {
         if (initialized) {
@@ -104,24 +103,20 @@ public final class Spark {
      * truststore. This has to be called before any route mapping is done. You
      * have to supply a keystore file, truststore file is optional (keystore
      * will be reused).
-     * 
+     * <p/>
      * This method is only relevant when using embedded Jetty servers. It should
      * not be used if you are using Servlets, where you will need to secure the
      * connection in the servlet container
-     * 
-     * @param keystoreFile
-     *            The keystore file location as string
-     * @param keystorePassword
-     *            the password for the keystore
-     * @param truststoreFile
-     *            the truststore file location as string, leave null to reuse
-     *            keystore
-     * @param truststorePassword
-     *            the trust store password
+     *
+     * @param keystoreFile       The keystore file location as string
+     * @param keystorePassword   the password for the keystore
+     * @param truststoreFile     the truststore file location as string, leave null to reuse
+     *                           keystore
+     * @param truststorePassword the trust store password
      */
     public static synchronized void setSecure(String keystoreFile,
-            String keystorePassword, String truststoreFile,
-            String truststorePassword) {
+                                              String keystorePassword, String truststoreFile,
+                                              String truststorePassword) {
         if (initialized) {
             throwBeforeRouteMappingException();
         }
@@ -140,9 +135,8 @@ public final class Spark {
     /**
      * Assign a route in classpath for static file. <b>Careful : this method
      * must be called before all others method.</b>
-     * 
-     * @param route
-     *            the route in classpath.
+     *
+     * @param route the route in classpath.
      */
     public static synchronized void staticFileRoute(String route) {
         if (initialized) {
@@ -153,9 +147,8 @@ public final class Spark {
 
     /**
      * Map the route for HTTP GET requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void get(Route route) {
         addRoute(HttpMethod.get.name(), route);
@@ -163,9 +156,8 @@ public final class Spark {
 
     /**
      * Map the route for HTTP POST requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void post(Route route) {
         addRoute(HttpMethod.post.name(), route);
@@ -173,19 +165,26 @@ public final class Spark {
 
     /**
      * Map the route for HTTP PUT requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void put(Route route) {
         addRoute(HttpMethod.put.name(), route);
     }
 
     /**
+     * Map the route for HTTP PATCH requests
+     *
+     * @param route The route
+     */
+    public static synchronized void patch(Route route) {
+        addRoute(HttpMethod.patch.name(), route);
+    }
+
+    /**
      * Map the route for HTTP DELETE requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void delete(Route route) {
         addRoute(HttpMethod.delete.name(), route);
@@ -193,9 +192,8 @@ public final class Spark {
 
     /**
      * Map the route for HTTP HEAD requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void head(Route route) {
         addRoute(HttpMethod.head.name(), route);
@@ -203,9 +201,8 @@ public final class Spark {
 
     /**
      * Map the route for HTTP TRACE requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void trace(Route route) {
         addRoute(HttpMethod.trace.name(), route);
@@ -213,9 +210,8 @@ public final class Spark {
 
     /**
      * Map the route for HTTP CONNECT requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void connect(Route route) {
         addRoute(HttpMethod.connect.name(), route);
@@ -223,9 +219,8 @@ public final class Spark {
 
     /**
      * Map the route for HTTP OPTIONS requests
-     * 
-     * @param route
-     *            The route
+     *
+     * @param route The route
      */
     public static synchronized void options(Route route) {
         addRoute(HttpMethod.options.name(), route);
@@ -233,9 +228,8 @@ public final class Spark {
 
     /**
      * Maps a filter to be executed before any matching routes
-     * 
-     * @param filter
-     *            The filter
+     *
+     * @param filter The filter
      */
     public static synchronized void before(Filter filter) {
         addFilter(HttpMethod.before.name(), filter);
@@ -243,9 +237,8 @@ public final class Spark {
 
     /**
      * Maps a filter to be executed after any matching routes
-     * 
-     * @param filter
-     *            The filter
+     *
+     * @param filter The filter
      */
     public static synchronized void after(Filter filter) {
         addFilter(HttpMethod.after.name(), filter);
@@ -282,7 +275,7 @@ public final class Spark {
         routeMatcher.parseValidateAddRoute(httpMethod + " '" + filter.getPath()
                 + "'", filter);
     }
-    
+
     private static synchronized void init() {
         if (!initialized) {
             routeMatcher = RouteMatcherFactory.get();
@@ -291,12 +284,12 @@ public final class Spark {
                 public void run() {
                     server = SparkServerFactory.create(staticFileRoute != null);
                     server.ignite(
-                            ipAddress, 
-                            port, 
+                            ipAddress,
+                            port,
                             keystoreFile,
-                            keystorePassword, 
+                            keystorePassword,
                             truststoreFile,
-                            truststorePassword, 
+                            truststorePassword,
                             staticFileRoute);
                 }
             }).start();

--- a/src/main/java/spark/route/HttpMethod.java
+++ b/src/main/java/spark/route/HttpMethod.java
@@ -17,10 +17,8 @@
 package spark.route;
 
 /**
- * 
- *
  * @author Per Wendel
  */
 public enum HttpMethod {
-    get, post, put, delete, head, trace, connect, options, before, after
+    get, post, put, patch, delete, head, trace, connect, options, before, after
 }

--- a/src/test/java/spark/servlet/ServletTest.java
+++ b/src/test/java/spark/servlet/ServletTest.java
@@ -1,12 +1,6 @@
 package spark.servlet;
 
-import static spark.util.SparkTestUtil.sleep;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
 import junit.framework.Assert;
-
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -14,65 +8,66 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import spark.TAccess;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
+
+import static spark.util.SparkTestUtil.sleep;
 
 public class ServletTest {
 
     private static final String SOMEPATH = "/somepath";
     private static final int PORT = 9393;
     static final Server server = new Server();
-    
+
     static SparkTestUtil testUtil;
-    
+
     @AfterClass
     public static void tearDown() {
         TAccess.clearRoutes();
         TAccess.stop();
     }
-    
+
     @BeforeClass
     public static void setup() {
-		testUtil = new SparkTestUtil(PORT);
-		
-		final Server server = new Server();
+        testUtil = new SparkTestUtil(PORT);
+
+        final Server server = new Server();
         ServerConnector connector = new ServerConnector(server);
-		
-		// Set some timeout options to make debugging easier.
-		connector.setIdleTimeout(1000 * 60 * 60);
-		connector.setSoLingerTime(-1);
-		connector.setPort(PORT);
-		server.setConnectors(new Connector[] { connector });
-		
-		WebAppContext bb = new WebAppContext();
-		bb.setServer(server);
-		bb.setContextPath(SOMEPATH);
-		bb.setWar("src/test/webapp");
-		
-		server.setHandler(bb);
-		
-		new Thread(new Runnable() {
+
+        // Set some timeout options to make debugging easier.
+        connector.setIdleTimeout(1000 * 60 * 60);
+        connector.setSoLingerTime(-1);
+        connector.setPort(PORT);
+        server.setConnectors(new Connector[]{connector});
+
+        WebAppContext bb = new WebAppContext();
+        bb.setServer(server);
+        bb.setContextPath(SOMEPATH);
+        bb.setWar("src/test/webapp");
+
+        server.setHandler(bb);
+
+        new Thread(new Runnable() {
             @Override
             public void run() {
                 try {
                     System.out.println(">>> STARTING EMBEDDED JETTY SERVER for jUnit testing of SparkFilter");
                     server.start();
                     System.in.read();
-                    System.out.println(">>> STOPPING EMBEDDED JETTY SERVER"); 
+                    System.out.println(">>> STOPPING EMBEDDED JETTY SERVER");
                     server.stop();
                     server.join();
                 } catch (Exception e) {
                     e.printStackTrace();
                     System.exit(100);
-                }        
+                }
             }
         }).start();
-		
-		sleep(1000);
+
+        sleep(1000);
     }
-    
+
     @Test
     public void testGetHi() {
         try {
@@ -83,7 +78,7 @@ public class ServletTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     public void testHiHead() {
         try {
@@ -94,7 +89,7 @@ public class ServletTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     public void testGetHiAfterFilter() {
         try {
@@ -104,7 +99,7 @@ public class ServletTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     public void testGetRoot() {
         try {
@@ -115,7 +110,7 @@ public class ServletTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     public void testEchoParam1() {
         try {
@@ -138,25 +133,26 @@ public class ServletTest {
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testUnauthorized() throws Exception {
         try {
-            testUtil.doMethod("GET", SOMEPATH + "/protected/resource", null);
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("401"));
-            throw e;
+            UrlResponse urlResponse = testUtil.doMethod("GET", SOMEPATH + "/protected/resource", null);
+            Assert.assertTrue(urlResponse.status == 401);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
         }
     }
 
-    @Test(expected = FileNotFoundException.class)
+    @Test
     public void testNotFound() throws Exception {
         try {
-            testUtil.doMethod("GET", SOMEPATH + "/no/resource", null);
-        } catch (Exception e) {
-            throw e;
+            UrlResponse urlResponse = testUtil.doMethod("GET", SOMEPATH + "/no/resource", null);
+            Assert.assertTrue(urlResponse.status == 404);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     public void testPost() {
         try {

--- a/src/test/java/spark/util/SparkTestUtil.java
+++ b/src/test/java/spark/util/SparkTestUtil.java
@@ -1,29 +1,47 @@
 package spark.util;
 
-import java.io.FileInputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.security.KeyStore;
-import java.util.List;
-import java.util.Map;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.*;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.BasicClientConnectionManager;
+import org.apache.http.util.EntityUtils;
 
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
-
-import spark.utils.IOUtils;
+import java.io.FileInputStream;
+import java.io.UnsupportedEncodingException;
+import java.security.KeyStore;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SparkTestUtil {
 
     private int port;
 
+    private HttpClient httpClient;
+
     public SparkTestUtil(int port) {
         this.port = port;
+        Scheme http = new Scheme("http", port, PlainSocketFactory.getSocketFactory());
+        Scheme https = new Scheme("https", port, new org.apache.http.conn.ssl.SSLSocketFactory(getSslFactory(), null));
+        SchemeRegistry sr = new SchemeRegistry();
+        sr.register(http);
+        sr.register(https);
+        ClientConnectionManager connMrg = new BasicClientConnectionManager(sr);
+        this.httpClient = new DefaultHttpClient(connMrg);
     }
 
     public UrlResponse doMethodSecure(String requestMethod, String path,
-            String body) throws Exception {
+                                      String body) throws Exception {
         return doMethod(requestMethod, path, body, true);
     }
 
@@ -33,31 +51,63 @@ public class SparkTestUtil {
     }
 
     private UrlResponse doMethod(String requestMethod, String path,
-            String body, boolean secureConnection) throws Exception {
-        URL url = new URL((secureConnection ? "https" : "http")
-                + "://localhost:" + port + path);
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                                 String body, boolean secureConnection) throws Exception {
 
-        if (secureConnection) {
-            HttpsURLConnection conn = (HttpsURLConnection) connection;
-            conn.setSSLSocketFactory(getSslFactory());
+        HttpUriRequest httpRequest = getHttpRequest(requestMethod, path, body, secureConnection);
+        HttpResponse httpResponse = httpClient.execute(httpRequest);
+
+        UrlResponse urlResponse = new UrlResponse();
+        urlResponse.status = httpResponse.getStatusLine().getStatusCode();
+        HttpEntity entity = httpResponse.getEntity();
+        if (entity != null) {
+            urlResponse.body = EntityUtils.toString(entity);
+        } else {
+            urlResponse.body = "";
+        }
+        Map<String, String> headers = new HashMap<>();
+        Header[] allHeaders = httpResponse.getAllHeaders();
+        for (Header header : allHeaders) {
+            headers.put(header.getName(), header.getValue());
+        }
+        urlResponse.headers = headers;
+        return urlResponse;
+    }
+
+    private HttpUriRequest getHttpRequest(String requestMethod, String path, String body, boolean secureConnection) {
+        try {
+            String protocol = secureConnection ? "https" : "http";
+            String uri = protocol + "://localhost:" + port + path;
+            //get, post, put, patch, delete, head, trace, connect, options
+            switch (requestMethod) {
+                case "GET":
+                    return new HttpGet(uri);
+                case "POST":
+                    HttpPost httpPost = new HttpPost(uri);
+                    httpPost.setEntity(new StringEntity(body));
+                    return httpPost;
+                case "PUT":
+                    HttpPut httpPut = new HttpPut(uri);
+                    httpPut.setEntity(new StringEntity(body));
+                    return httpPut;
+                case "PATCH":
+                    HttpPatch httpPatch = new HttpPatch(uri);
+                    httpPatch.setEntity(new StringEntity(body));
+                    return httpPatch;
+                case "DELETE":
+                    return new HttpDelete(uri);
+                case "HEAD":
+                    return new HttpHead(uri);
+                case "TRACE":
+                    return new HttpTrace(uri);
+                case "OPTIONS":
+                    return new HttpOptions(uri);
+                default:
+                    throw new IllegalArgumentException("Unknown method " + requestMethod);
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
         }
 
-        connection.setRequestMethod(requestMethod);
-
-        if (requestMethod.equals("POST") && body != null) {
-            connection.setDoOutput(true);
-            connection.getOutputStream().write(body.getBytes());
-        }
-
-        connection.connect();
-
-        String res = IOUtils.toString(connection.getInputStream());
-        UrlResponse response = new UrlResponse();
-        response.body = res;
-        response.status = connection.getResponseCode();
-        response.headers = connection.getHeaderFields();
-        return response;
     }
 
     public int getPort() {
@@ -67,14 +117,14 @@ public class SparkTestUtil {
     /**
      * Convenience method to use own truststore on SSL Sockets. Will default to
      * the self signed keystore provided in resources, but will respect
-     * 
+     * <p/>
      * -Djavax.net.ssl.keyStore=serverKeys
      * -Djavax.net.ssl.keyStorePassword=password
      * -Djavax.net.ssl.trustStore=serverTrust
      * -Djavax.net.ssl.trustStorePassword=password SSLApplication
-     * 
+     * <p/>
      * So these can be used to specify other key/trust stores if required.
-     * 
+     *
      * @return an SSL Socket Factory using either provided keystore OR the
      *         keystore specified in JVM params
      */
@@ -101,7 +151,7 @@ public class SparkTestUtil {
 
     /**
      * Return JVM param set keystore or default if not set.
-     * 
+     *
      * @return Keystore location as string
      */
     public static String getKeyStoreLocation() {
@@ -111,7 +161,7 @@ public class SparkTestUtil {
 
     /**
      * Return JVM param set keystore password or default if not set.
-     * 
+     *
      * @return Keystore password as string
      */
     public static String getKeystorePassword() {
@@ -122,7 +172,7 @@ public class SparkTestUtil {
     /**
      * Return JVM param set truststore location, or keystore location if not
      * set. if keystore not set either, returns default
-     * 
+     *
      * @return truststore location as string
      */
     public static String getTrustStoreLocation() {
@@ -133,7 +183,7 @@ public class SparkTestUtil {
     /**
      * Return JVM param set truststore password or keystore password if not set.
      * If still not set, will return default password
-     * 
+     *
      * @return truststore password as string
      */
     public static String getTrustStorePassword() {
@@ -144,7 +194,7 @@ public class SparkTestUtil {
 
     public static class UrlResponse {
 
-        public Map<String, List<String>> headers;
+        public Map<String, String> headers;
         public String body;
         public int status;
     }


### PR DESCRIPTION
Added support for PATCH. Had to refactor SparkTestUtil to use Apache HttpClient since Java's built in HTTPUrlConnection doesn't support it. This in turn required a few tweaks to some of the junit tests. 

This closes issue #37
