### PR TITLE
Make routes case-sensitive

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -375,7 +375,7 @@ public class Request {
                                 + matchedPart
                                 + " = "
                                 + request.get(i));
-                paramsToSet.put(matchedPart, request.get(i));
+                paramsToSet.put(matchedPart.toLowerCase(), request.get(i));
             }
         }
         return Collections.unmodifiableMap(paramsToSet);

--- a/src/main/java/spark/route/SimpleRouteMatcher.java
+++ b/src/main/java/spark/route/SimpleRouteMatcher.java
@@ -154,7 +154,7 @@ public class SimpleRouteMatcher implements RouteMatcher {
         try {
             int singleQuoteIndex = route.indexOf(SINGLE_QUOTE);
             String httpMethod = route.substring(0, singleQuoteIndex).trim().toLowerCase(); // NOSONAR
-            String url = route.substring(singleQuoteIndex + 1, route.length() - 1).trim().toLowerCase(); // NOSONAR
+            String url = route.substring(singleQuoteIndex + 1, route.length() - 1).trim(); // NOSONAR
 
             // Use special enum stuff to get from value
             HttpMethod method;

--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -76,7 +76,7 @@ public class MatcherFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
         String httpMethodStr = httpRequest.getMethod().toLowerCase(); // NOSONAR
-        String uri = httpRequest.getRequestURI().toLowerCase(); // NOSONAR
+        String uri = httpRequest.getRequestURI(); // NOSONAR
 
         String bodyContent = null;
 

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -178,6 +178,50 @@ public class GenericIntegrationTest {
     }
 
     @Test
+    public void testEchoParamWithUpperCaseInValue() {
+        final String camelCased = "ThisIsAValueAndSparkShouldRetainItsUpperCasedCharacters";
+        try {
+            UrlResponse response = testUtil.doMethod("GET", "/param/" + camelCased, null);
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("echo: " + camelCased, response.body);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testTwoRoutesWithDifferentCaseButSameName() {
+        String lowerCasedRoutePart = "param";
+        String uppperCasedRoutePart = "PARAM";
+
+        registerEchoRoute(lowerCasedRoutePart);
+        registerEchoRoute(uppperCasedRoutePart);
+        try {
+            assertEchoRoute(lowerCasedRoutePart);
+            assertEchoRoute(uppperCasedRoutePart);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void registerEchoRoute(final String routePart) {
+        get(new Route("/tworoutes/" + routePart + "/:param") {
+            @Override
+            public Object handle(Request request, Response response) {
+                return routePart + " route: " + request.params(":param");
+            }
+        });
+    }
+
+    private void assertEchoRoute(String routePart) throws Exception {
+        final String expected = "expected";
+        UrlResponse response = testUtil.doMethod("GET", "/tworoutes/" + routePart + "/" + expected, null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals(routePart + " route: " + expected, response.body);
+    }
+
+
+    @Test
     public void testEchoParamWithMaj() {
         try {
             UrlResponse response = testUtil.doMethod("GET", "/paramwithmaj/plop", null);


### PR DESCRIPTION
This fixes at least two issues, both of which we added integration tests for:
1. With  a route defined using "/route/:param", when doing a request on
  "/route/MyValue", request.params("param") would return the lowercased "myvalue"
2. When defining two routes "/route/:param" and "/ROUTE/:param", it would invoke
  the first match even doing a request on "/ROUTE/foo"

RFC2616, Setion 3.2.3 (URI Comparison) says the following on the topic (note it
only comments on client behavior, but if a client treats two URIs as being
different, the server should adhere to this all the more):

>    When comparing two URIs to decide if they match or not, a client
>    SHOULD use a case-sensitive octet-by-octet comparison of the entire
>    URIs, with these exceptions:
> 
> ```
>   - A port that is empty or not given is equivalent to the default
>     port for that URI-reference;
> 
>     - Comparisons of host names MUST be case-insensitive;
> 
>     - Comparisons of scheme names MUST be case-insensitive;
> 
>     - An empty abs_path is equivalent to an abs_path of "/".
> ```
