### PR TITLE
Upgrade to Jetty 9.0.2.v20130417

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         </developers>
 
 	<properties>
-		<jetty.version>9.0.0.v20130308</jetty.version>
+		<jetty.version>9.0.2.v20130417</jetty.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 


### PR DESCRIPTION
Initial Jetty 9 release had some performance issues and leaked
resources. Those and more bugs are fixed with the new release.

Issue: 63
