### PR TITLE
Binary-safe Response and Requests

### DIFF
--- a/src/main/java/spark/Access.java
+++ b/src/main/java/spark/Access.java
@@ -20,8 +20,8 @@ public final class Access {
 
     private Access() {}
     
-    public static String getBody(Response response) {
-        return response.body();
+    public static byte[] getBodyBytes(Response response) {
+        return response.bodyBytes();
     }
 
     public static void runFromServlet() {

--- a/src/main/java/spark/HaltException.java
+++ b/src/main/java/spark/HaltException.java
@@ -16,6 +16,8 @@
  */
 package spark;
 
+import spark.utils.SparkUtils;
+
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -27,7 +29,7 @@ public class HaltException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     
     private int statusCode = HttpServletResponse.SC_OK;
-    private String body = null;
+    private byte[] body = null;
     
     HaltException() {
         super();
@@ -38,12 +40,12 @@ public class HaltException extends RuntimeException {
     }
     
     HaltException(String body) {
-        this.body = body;
+        this.body = SparkUtils.stringToBytes(body);
     }
     
     HaltException(int statusCode, String body) {
         this.statusCode = statusCode;
-        this.body = body;
+        this.body = SparkUtils.stringToBytes(body);
     }
 
     /**
@@ -55,10 +57,17 @@ public class HaltException extends RuntimeException {
 
     
     /**
-     * @return the body
+     * @return the body bytes
      */
-    public String getBody() {
+    public byte[] getBodyBytes() {
         return body;
     }
-    
+
+	/**
+	 * @return the body string
+	 */
+	public String getBody() {
+		return SparkUtils.bytesToString(body);
+	}
+
 }

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -56,7 +56,7 @@ public class Request {
     private Session session = null;
     
     /* Lazy loaded stuff */
-    private String body = null;
+    private byte[] body = null;
     
     private Set<String> headers = null;
     
@@ -195,16 +195,25 @@ public class Request {
      * Returns the request body sent by the client
      */
     public String body() {
-        if (body == null) {
-            try {
-                body = IOUtils.toString(servletRequest.getInputStream());
-            } catch (Exception e) {
-                LOG.warn("Exception when reading body", e);
-            }
-        }
-        return body;
+		if (body == null)
+			bodyBytes();
+		return body != null ? SparkUtils.bytesToString(body) : null;
     }
-    
+
+	/**
+	 * Returns the raw request body sent by the client
+	 */
+	public byte[] bodyBytes() {
+		if (body == null) {
+			try {
+				body = IOUtils.toByteArray(servletRequest.getInputStream());
+			} catch (Exception e) {
+				LOG.warn("Exception when reading body", e);
+			}
+		}
+		return body;
+	}
+
     /**
      * Returns the length of request.body
      */
@@ -375,7 +384,7 @@ public class Request {
         LOG.debug("get params");
 
         Map<String, String> params = new HashMap<String, String>();
-        
+
         for (int i = 0; (i < request.size()) && (i < matched.size()); i++) {
             String matchedPart = matched.get(i);
             if (SparkUtils.isParam(matchedPart)) {

--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import spark.utils.SparkUtils;
 
 /**
  * Provides functionality for modifying the response
@@ -35,7 +36,7 @@ public class Response {
     private static final Logger LOG = LoggerFactory.getLogger(Response.class);
 
     private HttpServletResponse response;
-    private String body;
+    private byte[] body;
     
     protected Response() {
        // Used by wrapper
@@ -64,13 +65,24 @@ public class Response {
      * Sets the body
      */
     public void body(String body) {
-       this.body = body;
+       this.body = SparkUtils.stringToBytes(body);
     }
-    
+
+	/**
+	 * Sets the raw body
+	 */
+	public void bodyBytes(byte[] body) {
+		this.body = body;
+	}
+
     public String body() {
-       return this.body;
+       return SparkUtils.bytesToString(this.body);
     }
-    
+
+	public byte[] bodyBytes() {
+		return this.body;
+	}
+
     /**
      * Gets the raw response object handed in by Jetty
      */

--- a/src/main/java/spark/utils/IOUtils.java
+++ b/src/main/java/spark/utils/IOUtils.java
@@ -24,6 +24,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.io.ByteArrayOutputStream;
 
 
 /**
@@ -204,5 +205,17 @@ public final class IOUtils {
         }
         return count;
     }
+
+	public static byte[] toByteArray(InputStream istream) throws IOException {
+		byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+		ByteArrayOutputStream result = new ByteArrayOutputStream(istream.available());
+		while (true) {
+			int n = istream.read(buffer, 0, buffer.length);
+			if (n == -1)
+				break;
+			result.write(buffer, 0, n);
+		}
+		return result.toByteArray();
+	}
 
 }

--- a/src/main/java/spark/utils/SparkUtils.java
+++ b/src/main/java/spark/utils/SparkUtils.java
@@ -16,6 +16,7 @@
  */
 package spark.utils;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,5 +49,28 @@ public final class SparkUtils {
     public static boolean isSplat(String routePart) {
         return routePart.equals("*");
     }
-    
+
+	/**
+	 * Define this in a single place, so that we aren't subject to the system-dependent local character set.
+	 * This also wraps the exception, which we can reasonably expect to never be thrown.
+	 */
+	public static byte[] stringToBytes(String str) {
+		try {
+			return str.getBytes("UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			return ("Spark: utf-8 not supported (string to bytes)").getBytes();
+		}
+	}
+
+	/**
+	 * This is the converse of stringToBytes.
+	 */
+	public static String bytesToString(byte[] bytes) {
+		try {
+			return new String(bytes, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			return "Spark: utf-8 not supported (bytes to string)";
+		}
+	}
+
 }

--- a/src/main/java/spark/webserver/RequestWrapper.java
+++ b/src/main/java/spark/webserver/RequestWrapper.java
@@ -63,6 +63,11 @@ final class RequestWrapper extends Request {
         return delegate.body();
     }
 
+	@Override
+	public byte[] bodyBytes() {
+		return delegate.bodyBytes();
+	}
+
     @Override
     public int contentLength() {
         return delegate.contentLength();

--- a/src/main/java/spark/webserver/ResponseWrapper.java
+++ b/src/main/java/spark/webserver/ResponseWrapper.java
@@ -38,6 +38,11 @@ class ResponseWrapper extends Response {
         delegate.body(body);
     }
 
+	@Override
+	public void bodyBytes(byte[] body) {
+		delegate.bodyBytes(body);
+	}
+
     @Override
     public boolean equals(Object obj) {
         return delegate.equals(obj);


### PR DESCRIPTION
Many internal buffers have been changed from String to
byte[]. Wherever we need to convert between the two, we
use the function SparkUtils.stringToBytes or
SparkUtils.bytesToString, which uses UTF-8 always.

In order to read the request body as a byte[], one uses
Request.bodyBytes().

In order to write a response as a byte[], one simply
returns a byte[] from the handler.

All the existing tests pass without alteration,
so I hope this doesn't break existing code.

There is one new test which demonstrates the binary-safe IO.