### PR TITLE
Access all Request params from the Request object

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -120,6 +120,16 @@ public class Request {
     }
     
     /**
+     * Returns a map of the parameter names.
+     * Example: ':name' => 'value' in /hello/value for the route /hello/:name
+     * 
+     * @return null if there are no parameters.
+     */
+    public String params() {
+        return params;
+    }
+    
+    /**
      * Returns an arrat containing the splat (wildcard) parameters 
      */
     public String[] splat() {


### PR DESCRIPTION
It would be nice to have access to the named parameter map from the request object.
