### PR TITLE
When Spark returns 404 ("The requested route has not been mapped in Spark"), I'd like it to tell me the request URL that failed. 

### DIFF
--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -190,7 +190,7 @@ public class MatcherFilter implements Filter {
         
         if (!consumed && !isServletContext) {
             httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            bodyContent = NOT_FOUND;
+            bodyContent = String.format(NOT_FOUND, httpRequest.getRequestURL().toString());
             consumed = true;
         }
 
@@ -208,6 +208,6 @@ public class MatcherFilter implements Filter {
         // TODO Auto-generated method stub
     }
 
-    private static final String NOT_FOUND = "<html><body><h2>404 Not found</h2>The requested route has not been mapped in Spark</body></html>";
+    private static final String NOT_FOUND = "<html><body><h2>404 Not found</h2>The requested route [%s] has not been mapped in Spark</body></html>";
     private static final String INTERNAL_ERROR = "<html><body><h2>500 Internal Error</h2></body></html>";
 }


### PR DESCRIPTION
Can be handy sometimes. E.g: I'm using Spark as a stub for some backend REST services when developing a web client for those services. Not always sure of what my client is doing (hey, nobody's perfect right ;)), so this small addition helps me a lot. 

This may be useful for others, hence the pull request. 
