### PR TITLE
Exposed the ServletRequest's contextPath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>com.sparkjava</groupId>
 	<artifactId>spark-core</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0</version>
+	<version>1.1-SNAPSHOT</version>
 	<name>Spark</name>
         <description>A Sinatra inspired java web framework</description>
 	<url>http://www.sparkjava.com</url>

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -16,6 +16,14 @@
  */
 package spark;
 
+import spark.route.HttpMethod;
+import spark.route.RouteMatch;
+import spark.utils.IOUtils;
+import spark.utils.SparkUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -25,15 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import spark.route.HttpMethod;
-import spark.route.RouteMatch;
-import spark.utils.IOUtils;
-import spark.utils.SparkUtils;
 
 /**
  * Provides information about the HTTP request
@@ -63,6 +62,7 @@ public class Request {
     //    request.body              # request body sent by the client (see below), DONE
     //    request.scheme            # "http"                                DONE
     //    request.path_info         # "/foo",                               DONE
+    //    request.context_path      # "/foo",                               DONE
     //    request.port              # 80                                    DONE
     //    request.request_method    # "GET",                                DONE
     //    request.query_string      # "",                                   DONE
@@ -169,8 +169,16 @@ public class Request {
     public String pathInfo() {
         return servletRequest.getPathInfo();
     }
-    
-    /**
+
+	/**
+	 * Returns the context path
+	 * Example return: "/appName"
+	 */
+	 public String contextPath() {
+        return servletRequest.getContextPath();
+	 }
+
+	/**
      * Returns the URL string
      */
     public String url() {

--- a/src/main/java/spark/webserver/RequestWrapper.java
+++ b/src/main/java/spark/webserver/RequestWrapper.java
@@ -16,14 +16,13 @@
  */
 package spark.webserver;
 
-import java.util.Map;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-
 import spark.QueryParamsMap;
 import spark.Request;
 import spark.Session;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Set;
 
 final class RequestWrapper extends Request {
 
@@ -51,6 +50,11 @@ final class RequestWrapper extends Request {
     @Override
     public String pathInfo() {
         return delegate.pathInfo();
+    }
+
+	 @Override
+	 public String contextPath() {
+		  return delegate.contextPath();
     }
 
     @Override


### PR DESCRIPTION
When deploying as a war to Tomcat, it is necessary to know the contextPath.
Exposed the contextPath in the Request.

(Perhaps the Request.servletRequest should be protected, or have a getter?)
