### PR TITLE
Make generic declaration Java 6 compatible

### DIFF
--- a/src/main/java/spark/route/SimpleRouteMatcher.java
+++ b/src/main/java/spark/route/SimpleRouteMatcher.java
@@ -247,7 +247,7 @@ public class SimpleRouteMatcher implements RouteMatcher {
 
     //can be cached? I don't think so.
     private Map<String, RouteEntry> getAcceptedMimeTypes(List<RouteEntry> routes) {
-    	Map<String, RouteEntry> acceptedTypes = new HashMap<>();
+    	Map<String, RouteEntry> acceptedTypes = new HashMap<String, RouteEntry>();
     	
     	for (RouteEntry routeEntry : routes) {
     		if(!acceptedTypes.containsKey(routeEntry.acceptedType)) {


### PR DESCRIPTION
With this edit, Spark can be built by a Java 6 compiler.
