### PR TITLE
Content-Type should be modified only once, ie. in this case ignored by MatcherFilter

### DIFF
--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -46,6 +46,8 @@ import spark.route.RouteMatcher;
 public class MatcherFilter implements Filter {
 
     private static final String ACCEPT_TYPE_REQUEST_MIME_HEADER = "Accept";
+    private static final String CONTENT_TYPE_RESPONSE_HEADER = "Content-Type";
+
 	private RouteMatcher routeMatcher;
     private boolean isServletContext;
     private boolean hasOtherHandlers;
@@ -200,7 +202,9 @@ public class MatcherFilter implements Filter {
         if (consumed) {
             // Write body content
             if (!httpResponse.isCommitted()) {
-            	httpResponse.addHeader("Content-Type", acceptType);
+                if (httpResponse.getHeader(CONTENT_TYPE_RESPONSE_HEADER) == null) {
+                    httpResponse.setHeader(CONTENT_TYPE_RESPONSE_HEADER, acceptType);
+                }
                 httpResponse.getOutputStream().write(bodyContent.getBytes("utf-8"));
             }
         } else if (chain != null) {


### PR DESCRIPTION
Reasoning:

Modifying content type (actually it's appending here) header causes terrible failure when accessing content for example by Firefox browser, which sends really weird Accept headers to access the content.

Request for Firefox looks like this:

Accept: text/html,application/xhtml+xml,application/xml;q=0.9,_/_;q=0.8

...and response headers then contains multiple Content-Type lines even in case of explicit set by response.type("Content-Type", "text/html"):

Content-Type:text/html
Content-Type:_/_

This is actually so much limiting, that it makes spark useless for this particular case. But of course, I understand the idea about matching accept header on request with matching response content type handle. So I wrote this very simple patch, which only tries to set content-type response header in case, where developer didn't specified some other type himself.

Firefox for example reacts on Content-Type:_/_
by switchting to XML View of the markup. You can try yourself.
