### PR TITLE
Default Content-Type set to text/html using setContentType, also UTF-8

### DIFF
--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -46,7 +46,6 @@ import spark.route.RouteMatcher;
 public class MatcherFilter implements Filter {
 
     private static final String ACCEPT_TYPE_REQUEST_MIME_HEADER = "Accept";
-    private static final String CONTENT_TYPE_RESPONSE_HEADER = "Content-Type";
 
 	private RouteMatcher routeMatcher;
     private boolean isServletContext;
@@ -202,8 +201,8 @@ public class MatcherFilter implements Filter {
         if (consumed) {
             // Write body content
             if (!httpResponse.isCommitted()) {
-                if (httpResponse.getHeader(CONTENT_TYPE_RESPONSE_HEADER) == null) {
-                    httpResponse.setHeader(CONTENT_TYPE_RESPONSE_HEADER, acceptType);
+                if (null == httpResponse.getContentType()) {
+                    httpResponse.setContentType("text/html; charset=utf-8");
                 }
                 httpResponse.getOutputStream().write(bodyContent.getBytes("utf-8"));
             }


### PR DESCRIPTION
See description in issue #91 (https://github.com/perwendel/spark/issues/91)
Rather than recycling Accept request field as Content-Type in response, it would be better to default to text/html. Accept field is often not appropriate, especially not for Internet Explorer.
Also better to use setContentType rather than setHeader as Tomcat does not allow Content-Type to be set using the latter method.
