### PR TITLE
allow to list external directories via config

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -67,6 +67,8 @@ public final class Spark {
 
     private static String staticFileFolder = null;
     private static String externalStaticFileFolder = null;
+    
+    private static boolean listDirectories = false;
 
     // Hide constructor
     private Spark() {
@@ -98,6 +100,22 @@ public final class Spark {
         }
         Spark.port = port;
     }
+    
+    /**
+	 * Set whether external directories shall be listed or not. Note the
+	 * {@link #externalStaticFileLocation(String) externalStaticFileLocation}
+	 * must be set.
+	 * 
+	 * @param value
+	 *            the value as boolean flag
+	 * 
+	 */
+	public static synchronized void setListDirectories(boolean value) {
+		if (initialized) {
+			throwBeforeRouteMappingException();
+		}
+		Spark.listDirectories = value;
+	}
 
     /**
      * Set the connection to be secure, using the specified keystore and
@@ -309,7 +327,8 @@ public final class Spark {
                             truststoreFile,
                             truststorePassword,
                             staticFileFolder,
-                            externalStaticFileFolder);
+                            externalStaticFileFolder,
+                            listDirectories);
                 }
             }).start();
             initialized = true;

--- a/src/main/java/spark/webserver/SparkServer.java
+++ b/src/main/java/spark/webserver/SparkServer.java
@@ -35,6 +35,7 @@ public interface SparkServer {
      * @param truststorePassword - the trust store password
      * @param staticFilesRoute    - the route to static files in classPath
      * @param externalFilesLocation    - the route to static files external to classPath.
+     * @param listExternalDirectories    - the flag to allow external directories to be listed 
      */
     void ignite(
             String host, 
@@ -44,7 +45,8 @@ public interface SparkServer {
             String truststoreFile, 
             String truststorePassword,
             String staticFilesRoute,
-            String externalFilesLocation);
+            String externalFilesLocation,
+            boolean listExternalDirectories);
     
     /**
      * Stops the spark server

--- a/src/main/java/spark/webserver/SparkServerImpl.java
+++ b/src/main/java/spark/webserver/SparkServerImpl.java
@@ -51,7 +51,8 @@ class SparkServerImpl implements SparkServer {
     public void ignite(String host, int port, String keystoreFile,
             String keystorePassword, String truststoreFile,
             String truststorePassword, String staticFilesFolder,
-            String externalFilesFolder) {
+            String externalFilesFolder,
+            boolean listDirectories) {
         
         ServerConnector connector;
         
@@ -82,7 +83,7 @@ class SparkServerImpl implements SparkServer {
             setStaticFileLocationIfPresent(staticFilesFolder, handlersInList);
             
             // Set external static file location
-            setExternalStaticFileLocationIfPresent(externalFilesFolder, handlersInList);
+            setExternalStaticFileLocationIfPresent(externalFilesFolder, handlersInList, listDirectories);
 
             HandlerList handlers = new HandlerList();
             handlers.setHandlers(handlersInList.toArray(new Handler[handlersInList.size()]));
@@ -171,13 +172,14 @@ class SparkServerImpl implements SparkServer {
     /**
      * Sets external static file location if present
      */
-    private static void setExternalStaticFileLocationIfPresent(String externalFilesRoute, List<Handler> handlersInList) {
+    private static void setExternalStaticFileLocationIfPresent(String externalFilesRoute, List<Handler> handlersInList, boolean listDirectories) {
         if (externalFilesRoute != null) {
             try {
                 ResourceHandler externalResourceHandler = new ResourceHandler();
                 Resource externalStaticResources = Resource.newResource(new File(externalFilesRoute));
                 externalResourceHandler.setBaseResource(externalStaticResources);
                 externalResourceHandler.setWelcomeFiles(new String[] { "index.html" });
+                externalResourceHandler.setDirectoriesListed(listDirectories);
                 handlersInList.add(externalResourceHandler);
             } catch (IOException exception) {
                 exception.printStackTrace(); // NOSONAR


### PR DESCRIPTION
Hey Per,

Thanks first for this great piece of software, I really like the lightweight design. I had the use case to list directories of my external static file location. Jetty's resource handler provides a flag for that I just had extend sparks API with a setter for this (see the diff below). If you like this feature feel free to merge, I hope this fits into sparks design philosophy. 

regards
Andreas
