### PR TITLE
Add simple CORS support to Response

### DIFF
--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -185,4 +185,17 @@ public class Response {
         cookie.setMaxAge(0);
         response.addCookie(cookie);
     }
+
+    /**
+     * CORS support.
+     * 
+     * @param origin origin request header (comma-delimited list or *)
+     * @param methods supported HTTP methods (comma-delimited list or *)
+     * @param headers the headers supported by the server (comma-delimited list or *)
+     */
+    public void allowCORS(String origin, String methods, String headers) {
+        this.header("Access-Control-Allow-Origin", origin);
+        this.header("Access-Control-Request-Method", methods);
+        this.header("Access-Control-Allow-Headers", headers);
+    }    
 }


### PR DESCRIPTION
This is a quick CORS support inspired by [http://www.html5rocks.com/en/tutorials/cors/](http://www.html5rocks.com/en/tutorials/cors/)

to use it : `response.allowCORS("*", "*", "*")`
