### PR TITLE
remove link with outdated examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ NEWS: Spark 2.0.0 with Lambda support is now available on Maven central!!! :
 NEWS: Spark google group created:
 https://groups.google.com/d/forum/sparkjava
 
-Examples can also be viewed on: http://code.google.com/p/spark-java/
-
 Temporary API Docs: http://spark.screenisland.com
 
 Getting started


### PR DESCRIPTION
Examples on googlecode (https://code.google.com/p/spark-java/) use pre 2.0.0 syntax and the page on googlecode is outdated in general.

I'd suggest linking to github on the google code project page.
