### PR TITLE
added Request.bodyAsBytes()

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -16,6 +16,7 @@
  */
 package spark;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -55,6 +56,7 @@ public class Request {
 
     /* Lazy loaded stuff */
     private String body = null;
+    private byte[] bodyAsBytes = null;
 
     private Set<String> headers = null;
 
@@ -220,14 +222,26 @@ public class Request {
      */
     public String body() {
         if (body == null) {
-            try {
-                body = IOUtils.toString(servletRequest.getInputStream());
-            } catch (Exception e) {
-                LOG.warn("Exception when reading body", e);
-            }
+            readBody();
         }
         return body;
     }
+    
+    public byte[] bodyAsBytes() {
+        if (bodyAsBytes == null) {
+            readBody();
+        }
+        return bodyAsBytes;
+    }
+    
+    private void readBody() {
+		try {
+			bodyAsBytes = IOUtils.toByteArray(servletRequest.getInputStream());
+			body = IOUtils.toString(new ByteArrayInputStream(bodyAsBytes));
+		} catch (Exception e) {
+			LOG.warn("Exception when reading body", e);
+		}
+	}
 
     /**
      * @return the length of request.body
@@ -245,7 +259,7 @@ public class Request {
      */
     public String queryParams(String queryParam) {
         return servletRequest.getParameter(queryParam);
-    }
+    } 
 
     /**
      * Gets the value for the provided header

--- a/src/main/java/spark/utils/IOUtils.java
+++ b/src/main/java/spark/utils/IOUtils.java
@@ -16,6 +16,7 @@
  */
 package spark.utils;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -112,6 +113,29 @@ public final class IOUtils {
         return sw.toString();
     }
 
+	/**
+	 * Get the contents of an <code>InputStream</code> as a ByteArray
+	 * <p>
+	 * This method buffers the input internally, so there is no need to use a
+	 * <code>BufferedInputStream</code>.
+	 *
+	 * @param input
+	 *            the <code>InputStream</code> to read from
+	 * @return the byte array
+	 * @throws NullPointerException
+	 *             if the input is null
+	 * @throws IOException
+	 *             if an I/O error occurs
+	 */
+	public static byte[] toByteArray(InputStream input) throws IOException {
+		ByteArrayOutputStream os = new ByteArrayOutputStream();
+		byte[] buf = new byte[1024];
+		for (int n = input.read(buf); n != -1; n = input.read(buf)) {
+			os.write(buf, 0, n);
+		}
+		return os.toByteArray();
+	}
+    
     /**
      * Copy bytes from an <code>InputStream</code> to chars on a
      * <code>Writer</code> using the default character encoding of the platform.

--- a/src/main/java/spark/webserver/RequestWrapper.java
+++ b/src/main/java/spark/webserver/RequestWrapper.java
@@ -76,6 +76,11 @@ final class RequestWrapper extends Request {
     public String body() {
         return delegate.body();
     }
+    
+    @Override
+    public byte[] bodyAsBytes() {
+        return delegate.bodyAsBytes();
+    }
 
     @Override
     public int contentLength() {


### PR DESCRIPTION
Added possibility to get the body as bytes without needing to convert it to String.

This is useful if you need to POST stuff that's not convertible to String, such us images or other media content
