### PR TITLE
Build spark as OSGi bundle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <version>2.0.1-SNAPSHOT</version>
     <name>Spark</name>
     <description>A Sinatra inspired java web framework</description>
@@ -155,6 +155,15 @@
                 <configuration>
                 </configuration>
             </plugin>
+
+            <!-- to generate OSGi bundle -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.0</version>
+                <extensions>true</extensions>
+            </plugin>
+
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This little change to the pom.xml builds the JAR as an OSGi bundle so people can deploy spark in OSGi containers.