### PR TITLE
Allow overriding of HTTP method 

### DIFF
--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -81,7 +81,7 @@ public class MatcherFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) servletRequest; // NOSONAR
         HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
-        String httpMethodStr = httpRequest.getMethod().toLowerCase(); // NOSONAR
+        String httpMethodStr = getHttpMethodString(httpRequest); // NOSONAR
         String uri = httpRequest.getRequestURI(); // NOSONAR
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
@@ -230,7 +230,15 @@ public class MatcherFilter implements Filter {
         }
     }
 
-    public void destroy() {
+  private String getHttpMethodString(HttpServletRequest httpRequest) {
+    String method = httpRequest.getParameter("_method");
+    if(method == null) {
+      method = httpRequest.getMethod();
+    }
+    return method.toLowerCase();
+  }
+
+  public void destroy() {
         // TODO Auto-generated method stub
     }
 

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -104,6 +104,11 @@ public class GenericIntegrationTest {
             return "Body was: " + body;
         });
 
+        post("/post_via_get", (request, response) -> {
+            response.status(201); // created
+            return "Method Override Worked";
+        });
+
         patch("/patcher", (request, response) -> {
             String body = request.body();
             response.status(200);
@@ -324,6 +329,18 @@ public class GenericIntegrationTest {
             System.out.println(response.body);
             Assert.assertEquals(201, response.status);
             Assert.assertTrue(response.body.contains("Fo shizzy"));
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testPostViaGetWithMethodOverride() {
+        try {
+            UrlResponse response = testUtil.doMethod("GET", "/post_via_get?_method=post", "Fo shizzy");
+            System.out.println(response.body);
+            Assert.assertEquals(201, response.status);
+            Assert.assertTrue(response.body.contains("Method Override Worked"));
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Allow overriding of HTTP method used for matching via the "_method" request parameter.  This allows people to use RESTful URL definitions even with clients that don't support all the HTTP verbs (i.e.  most Javascript AJAX clients).  

This feature is taken from Rails.
