### PR TITLE
Fixed MimeParse Exception

### DIFF
--- a/src/main/java/spark/utils/MimeParse.java
+++ b/src/main/java/spark/utils/MimeParse.java
@@ -63,9 +63,18 @@ public class MimeParse {
         if (fullType.equals("*")) {
             fullType = "*/*";
         }
-        String[] types = fullType.split("/");
-        results.type = types[0].trim();
-        results.subType = types[1].trim();
+		
+		int slashIndex = fullType.indexOf('/');
+		if(slashIndex != -1) {
+			results.type = fullType.substring(0, slashIndex);
+			results.subType = fullType.substring(slashIndex + 1);
+		} else {
+			//If the type is invalid, attempt to turn into a wildcard
+			results.type = fullType;
+			results.subType = "*";
+		}
+			
+        
         return results;
     }
 


### PR DESCRIPTION
Fixed an issue with MimeParse that would cause it to raise an exception when an invalid Accept header, without a ‘/‘ separator, was parsed.
