### PR TITLE
clear static variables in SparkBase.stop

### DIFF
--- a/src/main/java/spark/SparkBase.java
+++ b/src/main/java/spark/SparkBase.java
@@ -224,6 +224,21 @@ public abstract class SparkBase {
             routeMatcher.clearRoutes();
             server.stop();
         }
+
+        port = SPARK_DEFAULT_PORT;
+        ipAddress = "0.0.0.0";
+
+        keystoreFile = null;
+        keystorePassword = null;
+        truststoreFile = null;
+        truststorePassword = null;
+
+        staticFileFolder = null;
+        externalStaticFileFolder = null;
+
+        server = null;
+        routeMatcher = null;
+
         initialized = false;
     }
 


### PR DESCRIPTION
This modification is to make junit tests finish correctly. Otherwise, after GenericSecureIntegrationTest sets keystoreFile to test secure, all the left non-secure tests would fail.