### PR TITLE
Updated the Request object to enable type capture on the attribute(String) method.

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -301,8 +301,8 @@ public class Request {
      * @param attribute The attribute value or null if not present
      * @return the value for the provided attribute
      */
-    public Object attribute(String attribute) {
-        return servletRequest.getAttribute(attribute);
+    public <T> T attribute(String attribute) {
+        return (T) servletRequest.getAttribute(attribute);
     }
 
 

--- a/src/main/java/spark/webserver/RequestWrapper.java
+++ b/src/main/java/spark/webserver/RequestWrapper.java
@@ -178,7 +178,7 @@ final class RequestWrapper extends Request {
     }
 
     @Override
-    public Object attribute(String attribute) {
+    public <T> T attribute(String attribute) {
         return delegate.attribute(attribute);
     }
 

--- a/src/test/java/spark/examples/filter/FilterExampleAttributes.java
+++ b/src/test/java/spark/examples/filter/FilterExampleAttributes.java
@@ -44,12 +44,12 @@ public class FilterExampleAttributes {
         });
 
         after("/hi", (request, response) -> {
-            Object foo = request.attribute("foo");
+            String foo = request.attribute("foo");
             response.body(asXml("foo", foo));
         });
     }
 
-    private static String asXml(String name, Object value) {
+    private static String asXml(String name, String value) {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?><" + name + ">" + value + "</" + name + ">";
     }
 


### PR DESCRIPTION
Improves the usability of the Request API, now that spark requires java 8.