### PR TITLE
Add throws declaration to the Route interface's handle method, so thrown...

### DIFF
--- a/src/main/java/spark/Route.java
+++ b/src/main/java/spark/Route.java
@@ -12,6 +12,6 @@ public interface Route {
      * @param response The response object providing functionality for modifying the response
      * @return The content to be set in the response
      */
-    Object handle(Request request, Response response);
+    Object handle(Request request, Response response) throws Exception;
 
 }


### PR DESCRIPTION
... exceptions won't cause compiler errors.
