### PR TITLE
Trie implementation for route matcher:

### DIFF
--- a/src/main/java/spark/SparkBase.java
+++ b/src/main/java/spark/SparkBase.java
@@ -3,8 +3,9 @@ package spark;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import spark.route.RouteMatcher;
+import spark.route.RouteMatcher.MatcherImplementation;
 import spark.route.RouteMatcherFactory;
-import spark.route.SimpleRouteMatcher;
 import spark.servlet.SparkFilter;
 import spark.webserver.SparkServer;
 import spark.webserver.SparkServerFactory;
@@ -31,12 +32,12 @@ public abstract class SparkBase {
     protected static String externalStaticFileFolder = null;
 
     protected static SparkServer server;
-    protected static SimpleRouteMatcher routeMatcher;
+    protected static RouteMatcher routeMatcher;
     private static boolean runFromServlet;
 
     private static boolean servletStaticLocationSet;
     private static boolean servletExternalStaticLocationSet;
-
+    
     /**
      * Set the IP address that Spark should listen on. If not called the default
      * address is '0.0.0.0'. This has to be called before any route mapping is
@@ -225,6 +226,13 @@ public abstract class SparkBase {
             server.stop();
         }
         initialized = false;
+    }
+    
+    /**
+     * Sets the RouteMatcher implementation
+     */
+    public static synchronized void matcher(MatcherImplementation matcher) {
+    	RouteMatcherFactory.impl = matcher;
     }
 
     static synchronized void runFromServlet() {

--- a/src/main/java/spark/route/RouteMatcher.java
+++ b/src/main/java/spark/route/RouteMatcher.java
@@ -1,0 +1,117 @@
+package spark.route;
+
+/**
+ * @author amarseillan
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import spark.utils.MimeParse;
+
+public abstract class RouteMatcher {
+	
+	private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(RouteMatcher.class);
+    private static final char SINGLE_QUOTE = '\'';
+
+	   /**
+     * Parse and validates a route and adds it
+     *
+     * @param route      the route path
+     * @param acceptType the accept type
+     * @param target     the invocation target
+     */
+    public void parseValidateAddRoute(String route, String acceptType, Object target) {
+    	try {
+            int singleQuoteIndex = route.indexOf(SINGLE_QUOTE);
+            String httpMethod = route.substring(0, singleQuoteIndex).trim().toLowerCase(); // NOSONAR
+            String url = route.substring(singleQuoteIndex + 1, route.length() - 1).trim(); // NOSONAR
+
+            // Use special enum stuff to get from value
+            HttpMethod method;
+            try {
+                method = HttpMethod.valueOf(httpMethod);
+            } catch (IllegalArgumentException e) {
+                LOG.error("The @Route value: "
+                                  + route
+                                  + " has an invalid HTTP method part: "
+                                  + httpMethod
+                                  + ".");
+                return;
+            }
+            addRoute(method, url, acceptType, target);
+        } catch (Exception e) {
+            LOG.error("The @Route value: " + route + " is not in the correct format", e);
+        }
+    }
+    
+    abstract void addRoute(HttpMethod method, String route, String acceptType, Object target);
+    
+    /**
+     * finds target for a requested route
+     *
+     * @param httpMethod the http method
+     * @param path       the path
+     * @param acceptType the accept type
+     * @return the target
+     */
+    public abstract RouteMatch findTargetForRequestedRoute(HttpMethod httpMethod, String path, String acceptType);
+    
+    /**
+     * Finds multiple targets for a requested route.
+     *
+     * @param httpMethod the http method
+     * @param path       the route path
+     * @param acceptType the accept type
+     * @return the targets
+     */
+    public abstract List<RouteMatch> findTargetsForRequestedRoute(HttpMethod httpMethod, String path, String acceptType);
+    
+    /**
+     * ¨Clear all routes
+     */
+    public abstract void clearRoutes();
+    
+    // TODO: I believe this feature has impacted performance. Optimization?
+    RouteEntry findTargetWithGivenAcceptType(List<RouteEntry> routeMatches, String acceptType) {
+        if (acceptType != null && routeMatches.size() > 0) {
+            Map<String, RouteEntry> acceptedMimeTypes = getAcceptedMimeTypes(routeMatches);
+            String bestMatch = MimeParse.bestMatch(acceptedMimeTypes.keySet(), acceptType);
+
+            if (routeWithGivenAcceptType(bestMatch)) {
+                return acceptedMimeTypes.get(bestMatch);
+            } else {
+                return null;
+            }
+        } else {
+            if (routeMatches.size() > 0) {
+                return routeMatches.get(0);
+            }
+        }
+
+        return null;
+    }
+    
+    boolean routeWithGivenAcceptType(String bestMatch) {
+        return !MimeParse.NO_MIME_TYPE.equals(bestMatch);
+    }
+    
+    //can be cached? I don't think so.
+    private Map<String, RouteEntry> getAcceptedMimeTypes(List<RouteEntry> routes) {
+        Map<String, RouteEntry> acceptedTypes = new HashMap<>();
+
+        for (RouteEntry routeEntry : routes) {
+            if (!acceptedTypes.containsKey(routeEntry.acceptedType)) {
+                acceptedTypes.put(routeEntry.acceptedType, routeEntry);
+            }
+        }
+
+        return acceptedTypes;
+    }
+    
+    public enum MatcherImplementation {
+    	list, trie
+    }
+    
+}

--- a/src/main/java/spark/route/RouteMatcherFactory.java
+++ b/src/main/java/spark/route/RouteMatcherFactory.java
@@ -16,6 +16,8 @@
  */
 package spark.route;
 
+import spark.Spark;
+import spark.route.RouteMatcher.MatcherImplementation;
 
 /**
  * RouteMatcherFactory
@@ -23,22 +25,33 @@ package spark.route;
  * @author Per Wendel
  */
 public final class RouteMatcherFactory {
-    /**
-     * The logger.
-     */
-    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(RouteMatcherFactory.class);
+	/**
+	 * The logger.
+	 */
+	private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory
+			.getLogger(RouteMatcherFactory.class);
 
-    private static SimpleRouteMatcher routeMatcher = null;
+	private static RouteMatcher routeMatcher = null;
+	public static MatcherImplementation impl = MatcherImplementation.list;
 
-    private RouteMatcherFactory() {
-    }
+	private RouteMatcherFactory() {
+	}
 
-    public static synchronized SimpleRouteMatcher get() {
-        if (routeMatcher == null) {
-            LOG.debug("creates RouteMatcher");
-            routeMatcher = new SimpleRouteMatcher();
-        }
-        return routeMatcher;
-    }
+	public static synchronized RouteMatcher get() {
+		if (routeMatcher == null) {
+			LOG.debug("creates RouteMatcher");
+			switch (impl) {
+				case list:
+					routeMatcher = new SimpleRouteMatcher();
+					break;
+				case trie:
+					routeMatcher = new TrieRouteMatcher();
+					break;
+				default:
+					throw new IllegalArgumentException();
+		}
+		}
+		return routeMatcher;
+	}
 
 }

--- a/src/main/java/spark/route/TrieRouteMatcher.java
+++ b/src/main/java/spark/route/TrieRouteMatcher.java
@@ -1,0 +1,154 @@
+package spark.route;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import spark.FilterImpl;
+import spark.RouteImpl;
+import spark.utils.MimeParse;
+import spark.utils.SparkUtils;
+import spark.utils.StringUtils;
+
+public class TrieRouteMatcher extends RouteMatcher{
+	
+	@Override
+	public RouteMatch findTargetForRequestedRoute(HttpMethod httpMethod,
+			String path, String acceptType) {
+		List<RouteEntry> routeEntries = findRoutes(root, StringUtils.trim(path, '/').split("/"), 0, httpMethod);
+		RouteEntry entry = findTargetWithGivenAcceptType(routeEntries, acceptType);
+        return entry != null ? new RouteMatch(httpMethod, entry.target, entry.path, path, acceptType) : null;
+	}
+
+	@Override
+	public List<RouteMatch> findTargetsForRequestedRoute(HttpMethod httpMethod,
+			String path, String acceptType) {
+		List<RouteMatch> matchSet = new ArrayList<>();
+		List<RouteEntry> routeEntries = new ArrayList<>();
+        findFilters(root, StringUtils.trim(path, '/').split("/"), 0, httpMethod, routeEntries);
+
+        for (RouteEntry routeEntry : routeEntries) {
+            if (acceptType != null) {
+                String bestMatch = MimeParse.bestMatch(Arrays.asList(routeEntry.acceptedType), acceptType);
+
+                if (routeWithGivenAcceptType(bestMatch)) {
+                    matchSet.add(new RouteMatch(httpMethod, routeEntry.target, routeEntry.path, path, acceptType));
+                }
+            } else {
+                matchSet.add(new RouteMatch(httpMethod, routeEntry.target, routeEntry.path, path, acceptType));
+            }
+        }
+
+        return matchSet;
+	}
+
+	@Override
+	public void clearRoutes() {
+		this.root = new Node();
+	}
+	
+	//-------------- Trie stuff!
+	
+	public TrieRouteMatcher() {
+		this.root = new Node();
+	}
+	
+	private Node root;
+
+	class Node {
+		Map<HttpMethod, List<RouteEntry>> filters;
+		Map<HttpMethod, List<RouteEntry>> routes;
+		Map<String, Node> children;
+
+		public Node() {
+			filters = new HashMap<>();
+			routes = new HashMap<>();
+			children = new HashMap<>();
+		}
+	}
+
+	synchronized void addRoute(HttpMethod method, String route, String acceptType, Object target) {
+		RouteEntry entry = new RouteEntry();
+        entry.httpMethod = method;
+        entry.path = route;
+        entry.target = target;
+        entry.acceptedType = acceptType;
+        if ((method == HttpMethod.before || method == HttpMethod.after)
+                && route.equals(SparkUtils.ALL_PATHS)) {
+        	addRoute(root, new String[]{}, 0, entry);
+        } else {
+		addRoute(root, StringUtils.trim(route, '/').split("/"), 0, entry);
+        }
+	}
+
+	private void addRoute(Node node, String[] route, int pos, RouteEntry entry) {
+		if (pos == route.length) {
+			if (entry.target instanceof RouteImpl) {
+				List<RouteEntry> list = node.routes.get(entry.httpMethod);
+				if (list == null) {
+					list = new ArrayList<>();
+				}
+				list.add(entry);
+				node.routes.put(entry.httpMethod, list);
+			} else if (entry.target instanceof FilterImpl) {
+				List<RouteEntry> list = node.filters.get(entry.httpMethod);
+				if (list == null) {
+					list = new ArrayList<>();
+				}
+				list.add(entry);
+				node.filters.put(entry.httpMethod, list);
+			}
+			return;
+		}
+
+		String word = route[pos];
+		if (word.startsWith(":")) {
+			word = "*";
+		}
+		if (!node.children.containsKey(word)) {
+			node.children.put(word, new Node());
+		}
+		addRoute(node.children.get(word), route, pos + 1, entry);
+	}
+	
+	private List<RouteEntry> findRoutes(Node node, String[] route, int pos, HttpMethod method) {
+		if (node == null) {
+			return new ArrayList<>();
+		}
+		if (route.length == pos) {
+			List<RouteEntry> entries = node.routes.get(method);
+			if (entries == null) {
+				entries = new ArrayList<>();
+			}
+			return entries;
+		}
+		
+		String word = route[pos];
+		if (!node.children.containsKey(word)) {
+			word = "*";
+		}
+		return findRoutes(node.children.get(word), route, pos+1, method);
+	}
+	
+	private void findFilters(Node node, String[] route, int pos, HttpMethod method, List<RouteEntry> filters) {
+		if (node == null) {
+			return;
+		}
+		List<RouteEntry> entries = node.filters.get(method);
+		if (entries != null) {
+			filters.addAll(entries);
+		}
+		if (route.length == pos) {
+			return;
+		}
+		
+		String word = route[pos];
+		if (!node.children.containsKey(word)) {
+			word = "*";
+		}
+		findFilters(node.children.get(word), route, pos+1, method, filters);
+	}
+	
+}

--- a/src/main/java/spark/utils/StringUtils.java
+++ b/src/main/java/spark/utils/StringUtils.java
@@ -354,5 +354,37 @@ public abstract class StringUtils {
     public static String collectionToDelimitedString(Collection<?> coll, String delim) {
         return collectionToDelimitedString(coll, delim, "", "");
     }
-
+    
+    /**
+     * Convenience method to trim a string for a specific value
+     * 
+     * @param input the String to trim
+     * @param c the char we want to trim
+     * @return the trimmed String
+     */
+    public static String trim(String input, char c) {
+    	if (input == null || input.length() < 1) {
+    		return input;
+    	}
+    	int start = 0;
+    	int end = input.length() - 1;
+    	char[] array = input.toCharArray();
+    	
+    	if (array[start] == c) {
+    		start++;
+    	}
+    	if (array[end] == c) {
+    		end--;
+    	}
+    	if (start > end) {
+    		return "";
+    	}
+    	
+    	char[] ret = new char[end+1-start];
+    	for (int i=0; i<ret.length; i++) {
+    		ret[i] = array[start+i];
+    	}
+    	
+    	return String.valueOf(ret);	
+    }
 }

--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -39,7 +39,7 @@ import spark.exception.ExceptionHandlerImpl;
 import spark.exception.ExceptionMapper;
 import spark.route.HttpMethod;
 import spark.route.RouteMatch;
-import spark.route.SimpleRouteMatcher;
+import spark.route.RouteMatcher;
 
 /**
  * Filter for matching of filters and routes.
@@ -50,7 +50,7 @@ public class MatcherFilter implements Filter {
 
     private static final String ACCEPT_TYPE_REQUEST_MIME_HEADER = "Accept";
 
-    private SimpleRouteMatcher routeMatcher;
+    private RouteMatcher routeMatcher;
     private boolean isServletContext;
     private boolean hasOtherHandlers;
 
@@ -66,7 +66,7 @@ public class MatcherFilter implements Filter {
      * @param isServletContext If true, chain.doFilter will be invoked if request is not consumed by Spark.
      * @param hasOtherHandlers If true, do nothing if request is not consumed by Spark in order to let others handlers process the request.
      */
-    public MatcherFilter(SimpleRouteMatcher routeMatcher, boolean isServletContext, boolean hasOtherHandlers) {
+    public MatcherFilter(RouteMatcher routeMatcher, boolean isServletContext, boolean hasOtherHandlers) {
         this.routeMatcher = routeMatcher;
         this.isServletContext = isServletContext;
         this.hasOtherHandlers = hasOtherHandlers;


### PR DESCRIPTION
Made RouteMatcher an abstract class to accept different implementations
The RouteMatcherFactory can serve different implementations

Follow the conversation of [this other pull request](https://github.com/perwendel/spark/pull/149).
Tests all pass with the new implementation but I didn't think of a way of gracefully testing both of the implementations without replicating every single test.

Used [this benchmark](https://github.com/augustl/spark/commit/58da36453b33175018cb7d120470d5a3db1f823e) and added filters to it and more routes/loops resulting in a 40% better performance.

Results:

BEFORE:

    RoutePerformanceTest.doBenchmark: [measured 10 out of 15 rounds, threads: 1 (sequential)]
    round: 34.27 [+- 1.09], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1502, GC.time: 3.01, time.total: 520.40, time.warmup: 177.70, time.bench: 342.70

AFTER:

    RoutePerformanceTest.doBenchmark: [measured 10 out of 15 rounds, threads: 1 (sequential)]
    round: 20.73 [+- 0.86], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 285, GC.time: 0.59, time.total: 313.37, time.warmup: 106.08, time.bench: 207.29