### PR TITLE
Redundant parameter defined on SparkFilter

### DIFF
--- a/src/main/java/spark/servlet/FilterTools.java
+++ b/src/main/java/spark/servlet/FilterTools.java
@@ -17,13 +17,13 @@
 package spark.servlet;
 
 import javax.servlet.FilterConfig;
+import javax.servlet.FilterRegistration;
 import javax.servlet.http.HttpServletRequest;
 
 final class FilterTools {
 
     private static final String SLASH_WILDCARD = "/*";
     private static final String SLASH = "/";
-    private static final String FILTER_MAPPING_PARAM = "filterMappingUrlPattern";
 
     private FilterTools() {
     }
@@ -53,12 +53,13 @@ final class FilterTools {
     }
 
     static String getFilterPath(FilterConfig config) {
-        String result = config.getInitParameter(FILTER_MAPPING_PARAM);
+        FilterRegistration registration = config.getServletContext().getFilterRegistration(config.getFilterName());
+        String result = registration.getUrlPatternMappings().iterator().next();
         if (result == null || result.equals(SLASH_WILDCARD)) {
             return "";
         } else if (!result.startsWith(SLASH) || !result.endsWith(SLASH_WILDCARD)) {
             throw new RuntimeException(
-                    "The " + FILTER_MAPPING_PARAM + " must start with \"/\" and end with \"/*\". It's: "
+                    "The mapping must start with \"/\" and end with \"/*\". It's: "
                             + result
             ); // NOSONAR
         }


### PR DESCRIPTION
I think the filterMappingUrlPattern init param for SparkFilter can be omitted because filters always must define a mapping.