### PR TITLE
fixed slf4j-simple dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.7</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- JETTY DEPENDENCIES -->


### PR DESCRIPTION
slf4j-simple is not a provided dependency - it just looks like it when running mvn builds because a maven plugin uses jetty 6 which provides this logging stub. Jetty 9 and the other spark dependencies do not. 

When actually built and run standalone, there is no logging facility at all  - 

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

So there are no logging messages. This change fixes this. 
