### PR TITLE
changed default to more secure loopback interface

### DIFF
--- a/src/main/java/spark/SparkBase.java
+++ b/src/main/java/spark/SparkBase.java
@@ -20,7 +20,7 @@ public abstract class SparkBase {
     protected static boolean initialized = false;
 
     protected static int port = SPARK_DEFAULT_PORT;
-    protected static String ipAddress = "0.0.0.0";
+    protected static String ipAddress = "127.0.0.1";
 
     protected static String keystoreFile;
     protected static String keystorePassword;


### PR DESCRIPTION
Binding to all interfaces is 'insecure by deault', beside also being somewhat too greedy. It also makes it harder to work on the spark code while also, say, running a spark project. Loopback interface seems like a more reasonable development default and in production, a specific external interface is usually selected/configured. 
