### PR TITLE
Adds Serializer class for serializing output data

### DIFF
--- a/src/main/java/spark/ResponseTransformerRouteImpl.java
+++ b/src/main/java/spark/ResponseTransformerRouteImpl.java
@@ -38,7 +38,7 @@ public abstract class ResponseTransformerRouteImpl extends RouteImpl {
                                                       ResponseTransformer transformer) {
         return new ResponseTransformerRouteImpl(path, acceptType) {
             @Override
-            public String render(Object model) throws Exception {
+            public Object render(Object model) throws Exception {
                 return transformer.render(model);
             }
 
@@ -59,6 +59,6 @@ public abstract class ResponseTransformerRouteImpl extends RouteImpl {
      * @param model object used to render output.
      * @return message that it is sent to client.
      */
-    public abstract String render(Object model) throws Exception;
+    public abstract Object render(Object model) throws Exception;
 
 }

--- a/src/main/java/spark/RouteImpl.java
+++ b/src/main/java/spark/RouteImpl.java
@@ -69,10 +69,9 @@ public abstract class RouteImpl implements Route {
      * @return body content.
      * @throws java.lang.Exception when render fails
      */
-    //TODO change String return type to Stream. It should be done in another issue.
-    public String render(Object element) throws Exception {
+    public Object render(Object element) throws Exception {
         if (element != null) {
-            return element.toString();
+            return element;
         } else {
             return null;
         }

--- a/src/main/java/spark/TemplateViewRouteImpl.java
+++ b/src/main/java/spark/TemplateViewRouteImpl.java
@@ -80,7 +80,7 @@ public abstract class TemplateViewRouteImpl extends RouteImpl {
 
 
     @Override
-    public String render(Object object) {
+    public Object render(Object object) {
         ModelAndView modelAndView = (ModelAndView) object;
         return render(modelAndView);
     }
@@ -102,6 +102,6 @@ public abstract class TemplateViewRouteImpl extends RouteImpl {
      * @param modelAndView object where object (mostly a POJO) and the name of the view to render are set.
      * @return message that it is sent to client.
      */
-    public abstract String render(ModelAndView modelAndView);
+    public abstract Object render(ModelAndView modelAndView);
 
 }

--- a/src/main/java/spark/webserver/BytesSerializer.java
+++ b/src/main/java/spark/webserver/BytesSerializer.java
@@ -1,0 +1,28 @@
+package spark.webserver;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+public class BytesSerializer extends Serializer {
+
+    @Override
+    public boolean canHandle(Object element) {
+        return element instanceof byte[] || element instanceof ByteBuffer;
+    }
+
+    @Override
+    public void process(OutputStream outputStream, Object element)
+            throws IOException {
+        byte[] bytes = null;
+        if(element instanceof byte[]) {
+            bytes = (byte[]) element;
+        } else {
+            if(element instanceof ByteBuffer) {
+                bytes = ((ByteBuffer) element).array();
+            }
+        }
+        outputStream.write(bytes);
+    }
+
+}

--- a/src/main/java/spark/webserver/DefaultSerializer.java
+++ b/src/main/java/spark/webserver/DefaultSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2011- Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.webserver;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Serilizer that writes the result of toString to output in UTF-8 encoding
+ * @author alsoto
+ */
+public class DefaultSerializer extends Serializer {
+
+    @Override
+    public boolean canHandle(Object element) {
+        return true;
+    }
+
+    @Override
+    public void process(OutputStream outputStream, Object element) throws IOException {
+        try {
+            outputStream.write(element.toString().getBytes("utf-8"));
+        } catch (UnsupportedEncodingException e) {
+           throw new IOException(e);
+        }
+    }
+
+}

--- a/src/main/java/spark/webserver/InputStreamSerializer.java
+++ b/src/main/java/spark/webserver/InputStreamSerializer.java
@@ -1,0 +1,23 @@
+package spark.webserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import spark.utils.IOUtils;
+
+public class InputStreamSerializer extends Serializer {
+
+    @Override
+    public boolean canHandle(Object element) {
+        return element instanceof InputStream;
+    }
+
+    @Override
+    public void process(OutputStream outputStream, Object element)
+            throws IOException {
+        String content = IOUtils.toString((InputStream) element);
+        outputStream.write(content.getBytes("utf-8"));
+    }
+
+}

--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -52,6 +52,7 @@ public class MatcherFilter implements Filter {
     private static final String HTTP_METHOD_OVERRIDE_HEADER = "X-HTTP-Method-Override";
 
     private SimpleRouteMatcher routeMatcher;
+    private SerializerChain serializerChain;
     private boolean isServletContext;
     private boolean hasOtherHandlers;
 
@@ -71,6 +72,7 @@ public class MatcherFilter implements Filter {
         this.routeMatcher = routeMatcher;
         this.isServletContext = isServletContext;
         this.hasOtherHandlers = hasOtherHandlers;
+        this.serializerChain = new SerializerChain();
     }
 
     public void init(FilterConfig filterConfig) {
@@ -90,7 +92,7 @@ public class MatcherFilter implements Filter {
         String uri = httpRequest.getRequestURI(); // NOSONAR
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
-        String bodyContent = null;
+        Object bodyContent = null;
 
         RequestWrapper requestWrapper = new RequestWrapper();
         ResponseWrapper responseWrapper = new ResponseWrapper();
@@ -138,7 +140,7 @@ public class MatcherFilter implements Filter {
 
             if (target != null) {
                 try {
-                    String result = null;
+                    Object result = null;
                     if (target instanceof RouteImpl) {
                         RouteImpl route = ((RouteImpl) target);
 
@@ -238,7 +240,7 @@ public class MatcherFilter implements Filter {
                 if (httpResponse.getContentType() == null) {
                     httpResponse.setContentType("text/html; charset=utf-8");
                 }
-                httpResponse.getOutputStream().write(bodyContent.getBytes("utf-8"));
+                serializerChain.process(httpResponse.getOutputStream(), bodyContent);
             }
         } else if (chain != null) {
             chain.doFilter(httpRequest, httpResponse);

--- a/src/main/java/spark/webserver/Serializer.java
+++ b/src/main/java/spark/webserver/Serializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011- Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.webserver;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Class that serializers and writes the result to given output stream.
+ * 
+ * @author alex
+ */
+public abstract class Serializer {
+
+    private Serializer next;
+
+    public void setNext(Serializer serializer) {
+        this.next = serializer;
+    }
+
+    public void processElement(OutputStream outputStream, Object element) throws IOException {
+        if(canHandle(element)) {
+            process(outputStream, element);
+        } else {
+            if(next != null) {
+                this.next.processElement(outputStream, element);
+            }
+        }
+    }
+
+    public abstract boolean canHandle(Object element);
+    public abstract void process(OutputStream outputStream, Object element) throws IOException;
+}

--- a/src/main/java/spark/webserver/SerializerChain.java
+++ b/src/main/java/spark/webserver/SerializerChain.java
@@ -1,0 +1,24 @@
+package spark.webserver;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class SerializerChain {
+
+    private Serializer root;
+    
+    public SerializerChain() {
+
+        DefaultSerializer defaultSerializer = new DefaultSerializer();
+        InputStreamSerializer inputStreamSerializer = new InputStreamSerializer();
+        inputStreamSerializer.setNext(defaultSerializer);
+        BytesSerializer bytesSerializer = new BytesSerializer();
+        bytesSerializer.setNext(inputStreamSerializer);
+        this.root = bytesSerializer;
+    }
+
+    public void process(OutputStream outputStream, Object element) throws IOException {
+        this.root.processElement(outputStream, element);
+    }
+    
+}

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -1,8 +1,20 @@
 package spark;
 
+import static spark.Spark.after;
+import static spark.Spark.before;
+import static spark.Spark.exception;
+import static spark.Spark.get;
+import static spark.Spark.halt;
+import static spark.Spark.patch;
+import static spark.Spark.post;
+import static spark.SparkBase.externalStaticFileLocation;
+import static spark.SparkBase.staticFileLocation;
+
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,26 +22,14 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import spark.examples.exception.BaseException;
 import spark.examples.exception.NotFoundException;
 import spark.examples.exception.SubclassOfBaseException;
-import spark.servlet.ServletTest;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
-
-import static spark.Spark.after;
-import static spark.Spark.before;
-import static spark.Spark.exception;
-import static spark.Spark.externalStaticFileLocation;
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.patch;
-import static spark.Spark.post;
-import static spark.Spark.staticFileLocation;
 
 public class GenericIntegrationTest {
 
@@ -81,6 +81,18 @@ public class GenericIntegrationTest {
         get("/hi", (request, response) -> {
             return "Hello World!";
         });
+
+        get("/binaryhi", (request, response) -> {
+           return "Hello World!".getBytes(); 
+        });
+
+        get("/bytebufferhi", (request, response) -> {
+            return ByteBuffer.wrap("Hello World!".getBytes()); 
+         });
+
+        get("/inputstreamhi", (request, response) -> {
+            return new ByteArrayInputStream("Hello World!".getBytes("utf-8"));
+         });
 
         get("/param/:param", (request, response) -> {
             return "echo: " + request.params(":param");
@@ -191,6 +203,39 @@ public class GenericIntegrationTest {
     public void testGetHi() {
         try {
             UrlResponse response = testUtil.doMethod("GET", "/hi", null);
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("Hello World!", response.body);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testGetBinaryHi() {
+        try {
+            UrlResponse response = testUtil.doMethod("GET", "/binaryhi", null);
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("Hello World!", response.body);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testGetByteBufferHi() {
+        try {
+            UrlResponse response = testUtil.doMethod("GET", "/bytebufferhi", null);
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("Hello World!", response.body);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testGetInputStreamHi() {
+        try {
+            UrlResponse response = testUtil.doMethod("GET", "/inputstreamhi", null);
             Assert.assertEquals(200, response.status);
             Assert.assertEquals("Hello World!", response.body);
         } catch (Throwable e) {


### PR DESCRIPTION
Adds Serializer interface for serializing output data to different formats instead of calling toString.

Before this PR the output was written to outputstream as a byte[] of a call to `toString` method. This works for almost all cases but if you want to return binary content (for example a dynamic generated pdf), then instead of writing the content of the pdf to output, it was written the result of calling `toString` method of a byte[] object which is totally wrong.

For this reason a Serializer abstract class has been created to implement a chain of responsibility pattern. Currently instead of calling `toString` method, Spark tries to resolve the output element. If it is a byte[] or ByteBuffer the output is written to output as is. If it is an InputStream then the inputstream is read and sent as byte[], and the default serializer is doing exactly as it was doing Spark, that is calling toString method.

If the proposed solution is accepted and merged, we can create a new issue which allows users to register its own serializers.

Note that developers are in charge of specifying the content type. 