### PR TITLE
Add OSGi bundle configuration to pom so that Spark will build as a bundle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <version>2.2-SNAPSHOT</version>
     <name>Spark</name>
     <description>A Sinatra inspired java web framework</description>
@@ -153,6 +153,12 @@
                 <version>2.9.1</version>
                 <configuration>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.3</version>
+                <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This supersedes pull request #121 (mine) which was conflicted. I resolved the conflict, but overly polluted the history, so here's a clean pull request.

This also supersedes pull request #164 (not mine) which had exactly the same changes and is now also conflicted.

As discussed previously, the only effect of this change is to add OSGi metadata into MANIFEST.MF, allowing the Spark jar to be seen as a bundle by any OSGi container. This change has absolutely no effect on anything other than the generated MANIFEST.MF file.