### PR TITLE
don't include logging in distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.7</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.7</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- JETTY DEPENDENCIES -->


### PR DESCRIPTION
Including slf4j at runtime is not needed. It can override logging downstream, and should be excluded.