### PR TITLE
issue #251:Session Invalidation Error

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -372,7 +372,7 @@ public class Request {
      * @return the session associated with this request
      */
     public Session session() {
-        if (session == null) {
+        if (session == null || session.raw() == null) {
             session = new Session(servletRequest.getSession());
         }
         return session;
@@ -388,7 +388,7 @@ public class Request {
      * <code>create</code> is <code>false</code> and the request has no valid session
      */
     public Session session(boolean create) {
-        if (session == null) {
+        if (session == null || session.raw() == null) {
             HttpSession httpSession = servletRequest.getSession(create);
             if (httpSession != null) {
                 session = new Session(httpSession);

--- a/src/main/java/spark/Session.java
+++ b/src/main/java/spark/Session.java
@@ -113,6 +113,7 @@ public class Session {
      */
     public void invalidate() {
         session.invalidate();
+	session = null;
     }
 
     /**


### PR DESCRIPTION
This is a fix for #251 . When Session is invalidate, the HttpSession variable is set to null. In the Request object, when using session, always check session.raw(). 

This is may not be a cleanest solution. Alternatively, Session could reference back to Request, so when invalidate, it cleans out the session variable in the Request object.