### PR TITLE
Reduced some boilerplate by adding SimpleRoute and associated methods.

### DIFF
--- a/src/main/java/spark/SimpleRoute.java
+++ b/src/main/java/spark/SimpleRoute.java
@@ -1,0 +1,13 @@
+package spark;
+
+/**
+ * Created by Marty Lamb on 2015-03-17.
+ */
+public interface SimpleRoute {
+
+    /**
+     * Invoked when a request is made on this route's corresponding path e.g. '/hello'
+     */
+    Object handle()  throws Exception;
+
+}

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -40,8 +40,7 @@ public final class Spark extends SparkBase {
     // Hide constructor
     private Spark() {
     }
-
-
+    
     /**
      * Map the route for HTTP GET requests
      *
@@ -50,6 +49,16 @@ public final class Spark extends SparkBase {
      */
     public static synchronized void get(final String path, final Route route) {
         addRoute(HttpMethod.get.name(), wrap(path, route));
+    }
+
+    /**
+     * Map the route for HTTP GET requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void get(final String path, final SimpleRoute route) {
+        get(path, wrap(route));
     }
 
     /**
@@ -63,6 +72,16 @@ public final class Spark extends SparkBase {
     }
 
     /**
+     * Map the route for HTTP POST requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void post(String path, SimpleRoute route) {
+        post(path, wrap(route));
+    }
+
+    /**
      * Map the route for HTTP PUT requests
      *
      * @param path  the path
@@ -70,6 +89,16 @@ public final class Spark extends SparkBase {
      */
     public static synchronized void put(String path, Route route) {
         addRoute(HttpMethod.put.name(), wrap(path, route));
+    }
+
+    /**
+     * Map the route for HTTP PUT requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void put(String path, SimpleRoute route) {
+        post(path, wrap(route));
     }
 
     /**
@@ -83,6 +112,16 @@ public final class Spark extends SparkBase {
     }
 
     /**
+     * Map the route for HTTP PATCH requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void patch(String path, SimpleRoute route) {
+        patch(path, wrap(route));
+    }
+
+    /**
      * Map the route for HTTP DELETE requests
      *
      * @param path  the path
@@ -90,6 +129,16 @@ public final class Spark extends SparkBase {
      */
     public static synchronized void delete(String path, Route route) {
         addRoute(HttpMethod.delete.name(), wrap(path, route));
+    }
+
+    /**
+     * Map the route for HTTP DELETE requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void delete(String path, SimpleRoute route) {
+        delete(path, wrap(route));
     }
 
     /**
@@ -103,6 +152,16 @@ public final class Spark extends SparkBase {
     }
 
     /**
+     * Map the route for HTTP HEAD requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void head(String path, SimpleRoute route) {
+        head(path, wrap(route));
+    }
+
+    /**
      * Map the route for HTTP TRACE requests
      *
      * @param path  the path
@@ -110,6 +169,16 @@ public final class Spark extends SparkBase {
      */
     public static synchronized void trace(String path, Route route) {
         addRoute(HttpMethod.trace.name(), wrap(path, route));
+    }
+
+    /**
+     * Map the route for HTTP TRACE requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void trace(String path, SimpleRoute route) {
+        trace(path, wrap(route));
     }
 
     /**
@@ -123,6 +192,16 @@ public final class Spark extends SparkBase {
     }
 
     /**
+     * Map the route for HTTP CONNECT requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void connect(String path, SimpleRoute route) {
+        connect(path, wrap(route));
+    }
+
+    /**
      * Map the route for HTTP OPTIONS requests
      *
      * @param path  the path
@@ -130,6 +209,16 @@ public final class Spark extends SparkBase {
      */
     public static synchronized void options(String path, Route route) {
         addRoute(HttpMethod.options.name(), wrap(path, route));
+    }
+
+    /**
+     * Map the route for HTTP OPTIONS requests
+     *
+     * @param path  the path
+     * @param route The route
+     */
+    public static synchronized void options(String path, SimpleRoute route) {
+        options(path, wrap(route));
     }
 
     /**

--- a/src/main/java/spark/SparkBase.java
+++ b/src/main/java/spark/SparkBase.java
@@ -37,6 +37,32 @@ public abstract class SparkBase {
     private static boolean servletStaticLocationSet;
     private static boolean servletExternalStaticLocationSet;
 
+    // store request and response in threadlocals to support SimpleRoute
+    private static final ThreadLocal<spark.Request> req = new ThreadLocal<>();
+    private static final ThreadLocal<spark.Response> rsp = new ThreadLocal<>();
+    
+    // only needs to be called by MatcherFilter
+    public static void setRequestResponse(Request request, Response response) {
+        req.set(request);
+        rsp.set(response);
+    }
+    
+    /**
+     * Returns the Request being handled by the current Thread
+     * @return the Request being handled by the current Thread
+     */
+    public static Request request() {
+        return req.get();
+    }
+    
+    /**
+     * Returns the Response being provided by the current Thread
+     * @return the Response being provided by the current Thread
+     */
+    public static Response response() {
+        return rsp.get();
+    }
+
     /**
      * Set the IP address that Spark should listen on. If not called the default
      * address is '0.0.0.0'. This has to be called before any route mapping is
@@ -235,6 +261,15 @@ public abstract class SparkBase {
         }
     }
 
+    /**
+     * Wraps the SimpleRoute in a Route
+     * @param sroute the SimpleRoute to wrap
+     * @return the wrapped SimpleRoute
+     */
+    protected static Route wrap(final SimpleRoute sroute) {
+        return (Request req, Response rsp) -> sroute.handle();
+    }
+    
     /**
      * Wraps the route in RouteImpl
      *

--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -35,6 +35,7 @@ import spark.Request;
 import spark.RequestResponseFactory;
 import spark.Response;
 import spark.RouteImpl;
+import spark.SparkBase;
 import spark.exception.ExceptionHandlerImpl;
 import spark.exception.ExceptionMapper;
 import spark.route.HttpMethod;
@@ -98,6 +99,7 @@ public class MatcherFilter implements Filter {
         Response response = RequestResponseFactory.create(httpResponse);
 
         LOG.debug("httpMethod:" + httpMethodStr + ", uri: " + uri);
+        SparkBase.setRequestResponse(requestWrapper, responseWrapper);
         try {
             // BEFORE filters
             List<RouteMatch> matchSet = routeMatcher.findTargetsForRequestedRoute(HttpMethod.before, uri, acceptType);
@@ -212,6 +214,8 @@ public class MatcherFilter implements Filter {
                 httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 bodyContent = INTERNAL_ERROR;
             }
+        } finally {
+            SparkBase.setRequestResponse(null, null); // don't hang on to these any longer than necessary
         }
 
         // If redirected and content is null set to empty string to not throw NotConsumedException

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -106,6 +106,14 @@ public class GenericIntegrationTest {
             return "Hello Root!";
         });
 
+        get("/simpleRoute", () -> "Success");
+        
+        get("/simpleRouteRequestResponse", () -> {
+            if (Spark.request() == null) return("Request was null!");
+            if (Spark.response() == null) return("Response was null!");
+            return "Success";
+        });
+        
         post("/poster", (request, response) -> {
             String body = request.body();
             response.status(201); // created
@@ -173,6 +181,19 @@ public class GenericIntegrationTest {
         }
     }
 
+    @Test
+    public void simpleRoute_should_return_success() throws Exception {
+        UrlResponse response = testUtil.doMethod("GET", "/simpleRoute", null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("Success", response.body);
+    }
+    
+    public void simpleRoute_should_have_access_to_request_and_response() throws Exception {
+        UrlResponse response = testUtil.doMethod("GET", "/simpleRouteRequestResponse", null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("Success", response.body);        
+    }
+    
     @Test
     public void routes_should_be_accept_type_aware() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/hi", null, "application/json");


### PR DESCRIPTION
SimpleRoute can be used in place of Route for the simpler route-adding
methods.  SimpleRoute provides a no-arg handle() method so that routes
can be added like this:

    get("/path", () -> "Hello");

instead of:

    get("/path", (request, response) -> "Hello");

Users of SimpleRoute can still access the request and response via the
new static methods request() and response() in SparkBase.  Internally,
these are stored within ThreadLocals managed by MatcherFilter.

At the moment, only the METHOD(String, SimpleRoute) methods have been
added.  If this path looks fruitful I'll implement the rest.