### PR TITLE
Remove obsolete param in a javadoc document

### DIFF
--- a/src/main/java/spark/utils/IOUtils.java
+++ b/src/main/java/spark/utils/IOUtils.java
@@ -173,7 +173,6 @@ public final class IOUtils {
     *
     * @param input the <code>InputStream</code> to read from
     * @param output the <code>OutputStream</code> to write to
-    * @param buffer the buffer to use for the copy
     * @return the number of bytes copied
     * @throws NullPointerException if the input or output is null
     * @throws IOException if an I/O error occurs


### PR DESCRIPTION
I found that `mvn javadoc:javadoc` fails in master branch with the following environment.

* oracle-java8 (Java 1.8.0_40)
* Maven 3.0.5
* Ubuntu 15.04 beta

The cause of the error was an extra, obsolete param in a javadoc document, so I wrote a patch.
