### PR TITLE
Remove references to deprecated setPort method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ public class SimpleExample {
 
     public static void main(String[] args) {
 
-        //  setPort(5678); <- Uncomment this if you wan't spark to listen on a port different than 4567.
+        //  port(5678); <- Uncomment this if you want spark to listen on a port different than 4567
 
         get("/hello", (request, response) -> "Hello World!");
 

--- a/src/test/java/spark/examples/simple/SimpleExample.java
+++ b/src/test/java/spark/examples/simple/SimpleExample.java
@@ -28,24 +28,18 @@ public class SimpleExample {
 
     public static void main(String[] args) {
 
-        //  setPort(5678); <- Uncomment this if you wan't spark to listen on a port different than 4567.
+        //  port(5678); <- Uncomment this if you want spark to listen on a port different than 4567
 
-        get("/hello", (request, response) -> {
-            return "Hello World!";
-        });
+        get("/hello", (request, response) -> "Hello World!");
 
-        post("/hello", (request, response) -> {
-            return "Hello World: " + request.body();
-        });
+        post("/hello", (request, response) -> "Hello World: " + request.body());
 
         get("/private", (request, response) -> {
             response.status(401);
             return "Go Away!!!";
         });
 
-        get("/users/:name", (request, response) -> {
-            return "Selected user: " + request.params(":name");
-        });
+        get("/users/:name", (request, response) -> "Selected user: " + request.params(":name"));
 
         get("/news/:section", (request, response) -> {
             response.type("text/xml");
@@ -62,9 +56,6 @@ public class SimpleExample {
             return null;
         });
 
-        get("/", (request, response) -> {
-            return "root";
-        });
-
+        get("/", (request, response) -> "root");
     }
 }

--- a/src/test/java/spark/examples/simple/SimpleSecureExample.java
+++ b/src/test/java/spark/examples/simple/SimpleSecureExample.java
@@ -37,22 +37,16 @@ public class SimpleSecureExample {
 
         secure(args[0], args[1], null, null);
 
-        get("/hello", (request, response) -> {
-            return "Hello Secure World!";
-        });
+        get("/hello", (request, response) -> "Hello Secure World!");
 
-        post("/hello", (request, response) -> {
-            return "Hello Secure World: " + request.body();
-        });
+        post("/hello", (request, response) -> "Hello Secure World: " + request.body());
 
         get("/private", (request, response) -> {
             response.status(401);
             return "Go Away!!!";
         });
 
-        get("/users/:name", (request, response) -> {
-            return "Selected user: " + request.params(":name");
-        });
+        get("/users/:name", (request, response) -> "Selected user: " + request.params(":name"));
 
         get("/news/:section", (request, response) -> {
             response.type("text/xml");
@@ -70,9 +64,6 @@ public class SimpleSecureExample {
             return null;
         });
 
-        get("/", (request, response) -> {
-            return "root";
-        });
-
+        get("/", (request, response) -> "root");
     }
 }


### PR DESCRIPTION
Related to https://github.com/perwendel/spark/issues/243