### PR TITLE
Use official HTTP 401 Unauthorized message name

### DIFF
--- a/src/main/java/spark/LambdaTest.java
+++ b/src/main/java/spark/LambdaTest.java
@@ -20,11 +20,11 @@ public class LambdaTest {
         });
 
         before("/protected/*", "application/xml", (request, response) -> {
-            halt(401, "<xml>fuck off</xml>");
+            halt(401, "<xml>Unauthorized</xml>");
         });
 
         before("/protected/*", "application/json", (request, response) -> {
-            halt(401, "{\"message\": \"Go Away!\"}");
+            halt(401, "{\"message\": \"Unauthorized\"}");
         });
 
     }


### PR DESCRIPTION
I personally appreciate the kicks and giggles that arise from the odd usage of this language, but it feels a bit weird to have this kind of message in what would potentially be production code.

In other words ... Rewording this can only be in the best of your project's interests ;)