### PR TITLE
changing exceptionMapper to be passed in as a arg to matcherFilter and adding public to Jetty handler

### DIFF
--- a/src/main/java/spark/servlet/SparkFilter.java
+++ b/src/main/java/spark/servlet/SparkFilter.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import spark.Access;
+import spark.exception.ExceptionMapper;
 import spark.resource.AbstractFileResolvingResource;
 import spark.resource.AbstractResourceHandler;
 import spark.resource.ClassPathResource;
@@ -71,7 +72,7 @@ public class SparkFilter implements Filter {
         application.init();
 
         filterPath = FilterTools.getFilterPath(filterConfig);
-        matcherFilter = new MatcherFilter(RouteMatcherFactory.get(), true, false);
+        matcherFilter = new MatcherFilter(RouteMatcherFactory.get(), ExceptionMapper.getInstance(), true, false);
     }
 
     /**
@@ -127,7 +128,6 @@ public class SparkFilter implements Filter {
                 }
             }
         }
-
         matcherFilter.doFilter(requestWrapper, response, chain);
     }
 

--- a/src/main/java/spark/webserver/JettyHandler.java
+++ b/src/main/java/spark/webserver/JettyHandler.java
@@ -38,7 +38,7 @@ import spark.utils.IOUtils;
  *
  * @author Per Wendel
  */
-class JettyHandler extends SessionHandler {
+public class JettyHandler extends SessionHandler {
 
     private static final Logger LOG = Log.getLogger(JettyHandler.class);
 

--- a/src/main/java/spark/webserver/SparkServerFactory.java
+++ b/src/main/java/spark/webserver/SparkServerFactory.java
@@ -16,6 +16,7 @@
  */
 package spark.webserver;
 
+import spark.exception.ExceptionMapper;
 import spark.route.RouteMatcherFactory;
 
 /**
@@ -27,7 +28,7 @@ public final class SparkServerFactory {
     }
 
     public static SparkServer create(boolean hasMultipleHandler) {
-        MatcherFilter matcherFilter = new MatcherFilter(RouteMatcherFactory.get(), false, hasMultipleHandler);
+        MatcherFilter matcherFilter = new MatcherFilter(RouteMatcherFactory.get(), ExceptionMapper.getInstance(), false, hasMultipleHandler);
         matcherFilter.init(null);
         JettyHandler handler = new JettyHandler(matcherFilter);
         return new SparkServer(handler);


### PR DESCRIPTION
A fix for issue described here: https://github.com/perwendel/spark/issues/281
