### PR TITLE
Add queryParamsValues to Request

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -263,6 +263,17 @@ public class Request {
     public String queryParams(String queryParam) {
         return servletRequest.getParameter(queryParam);
     } 
+    
+    /**
+     * gets all the values of the query param
+     *
+     * @param queryParam the query parameter
+     * @return the values of the provided queryParam, null if it doesn't exists
+     * Example: query parameter 'id' from the following request URI: /hello?id=foo&id=bar
+     */
+    public String[] queryParamsValues(String queryParam) {
+        return servletRequest.getParameterValues(queryParam);
+    } 
 
     /**
      * Gets the value for the provided header

--- a/src/main/java/spark/webserver/RequestWrapper.java
+++ b/src/main/java/spark/webserver/RequestWrapper.java
@@ -132,8 +132,13 @@ final class RequestWrapper extends Request {
     public String queryParams(String queryParam) {
         return delegate.queryParams(queryParam);
     }
-
+    
     @Override
+	public String[] queryParamsValues(String queryParam) {
+		return delegate.queryParamsValues(queryParam);
+	}
+
+	@Override
     public String headers(String header) {
         return delegate.headers(header);
     }


### PR DESCRIPTION
This method supports URLs like:

    http://host/resource?id=foo&id=bar

returning `request.getParamsValues("id")`as `["foo", "bar"]`

It simply delegates to the appropiate method in `HttpServletRequest`. Without it, the non-intuitive and a bit cumbersome way of getting this result is:

    QueryParamsMap paramMap = request.queryMap("id");
    if (paramMap.hasValue()) {
        whatever(paramMap.values())
    }