### PR TITLE
method `handle` of TemplateViewRoute can throw Exceptions

### DIFF
--- a/src/main/java/spark/TemplateViewRoute.java
+++ b/src/main/java/spark/TemplateViewRoute.java
@@ -34,6 +34,6 @@ public interface TemplateViewRoute {
      * @param response The response object providing functionality for modifying the response
      * @return The content to be set in the response
      */
-    ModelAndView handle(Request request, Response response);
+    ModelAndView handle(Request request, Response response) throws Exception;
 
 }


### PR DESCRIPTION
This restores the symmetry between the template operators and the other route types.