### PR TITLE
Jetty version 9.2.11.v20150529

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </developers>
 
     <properties>
-        <jetty.version>9.3.0.M2</jetty.version>
+        <jetty.version>9.2.11.v20150529</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     </developers>
 
     <properties>
-        <jetty.version>9.0.2.v20130417</jetty.version>
+        <jetty.version>9.3.0.M2</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/spark/JettyLogger.java
+++ b/src/main/java/spark/JettyLogger.java
@@ -111,4 +111,9 @@ public class JettyLogger implements Logger {
         logger.warn(log.toString());
     }
 
+    @Override
+    public void debug(String arg0, long arg1) {
+        logger.debug(arg0, arg1);
+    }
+
 }

--- a/src/main/java/spark/webserver/JettyHandler.java
+++ b/src/main/java/spark/webserver/JettyHandler.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import javax.servlet.Filter;
+import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -86,7 +87,7 @@ class JettyHandler extends SessionHandler {
 
         public class CachedServletInputStream extends ServletInputStream {
             private ByteArrayInputStream byteArrayInputStream;
-
+            
             public CachedServletInputStream() {
                 byteArrayInputStream = new ByteArrayInputStream(cachedBytes);
             }
@@ -95,6 +96,19 @@ class JettyHandler extends SessionHandler {
             public int read() {
                 return byteArrayInputStream.read();
             }
+
+            @Override
+            public boolean isFinished() {
+                return byteArrayInputStream.available() <= 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return byteArrayInputStream.available() >= 0;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {}
         }
     }
 }

--- a/src/main/java/spark/webserver/SparkServer.java
+++ b/src/main/java/spark/webserver/SparkServer.java
@@ -16,7 +16,6 @@
  */
 package spark.webserver;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
@@ -234,16 +233,10 @@ public class SparkServer {
     private static void setExternalStaticFileLocationIfPresent(String externalFilesRoute,
                                                                List<Handler> handlersInList) {
         if (externalFilesRoute != null) {
-            try {
-                ResourceHandler externalResourceHandler = new ResourceHandler();
-                Resource externalStaticResources = Resource.newResource(new File(externalFilesRoute));
-                externalResourceHandler.setBaseResource(externalStaticResources);
-                externalResourceHandler.setWelcomeFiles(new String[] {"index.html"});
-                handlersInList.add(externalResourceHandler);
-            } catch (IOException exception) {
-                exception.printStackTrace(); // NOSONAR
-                System.err.println("Error during initialize external resource " + externalFilesRoute); // NOSONAR
-            }
+            ResourceHandler externalResourceHandler = new ResourceHandler();
+            externalResourceHandler.setResourceBase(externalFilesRoute);
+            externalResourceHandler.setWelcomeFiles(new String[] {"index.html"});
+            handlersInList.add(externalResourceHandler);
         }
     }
 

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -24,6 +24,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
 import javax.servlet.http.Part;
 
 import org.junit.Test;
@@ -421,6 +422,25 @@ public class RequestTest {
 
 		@Override
 		public Part getPart(String name) throws IOException, ServletException {
+			return null;
+		}
+
+		@Override
+		public long getContentLengthLong() {
+			// TODO Auto-generated method stub
+			return 0;
+		}
+
+		@Override
+		public String changeSessionId() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass)
+				throws IOException, ServletException {
+			// TODO Auto-generated method stub
 			return null;
 		}
         

--- a/src/test/java/spark/servlet/ServletTest.java
+++ b/src/test/java/spark/servlet/ServletTest.java
@@ -68,8 +68,11 @@ public class ServletTest {
                 }
             }
         }).start();
-
-        sleep(1000);
+        
+        while(!server.isStarted()){
+            sleep(1000);
+            LOGGER.info(">>> WAITING FOR EMBEDDED JETTY SERVER TO START");
+        }
     }
 
     @Test


### PR DESCRIPTION
Update of jetty version from 9.0.2.v20130417 to 9.2.11.v20150529. This new version come with javax.servlet-api:3.1, better startup time, ThreadPool bugs fixed and other improvements that can be found here [Jetty 9.2.11 Roadmap](http://git.eclipse.org/c/jetty/org.eclipse.jetty.project.git/tree/VERSION.txt?id=jetty-9.2.11.v20150529).

@perwendel Can you validate these changes please?

