### PR TITLE
Automatically decode query string values

### DIFF
--- a/src/main/java/spark/QueryParamsMap.java
+++ b/src/main/java/spark/QueryParamsMap.java
@@ -1,5 +1,7 @@
 package spark;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,7 +50,7 @@ public class QueryParamsMap {
     /**
      * Creates a new QueryParamsMap from and HttpServletRequest. <br>
      * Parses the parameters from request.getParameterMap() <br>
-     * No need to decode, since HttpServletRequest does it for us.
+     * All values will be URL-decoded.
      *
      * @param request the servlet request
      */
@@ -93,7 +95,15 @@ public class QueryParamsMap {
      */
     protected final void loadQueryString(Map<String, String[]> params) {
         for (Map.Entry<String, String[]> param : params.entrySet()) {
-            loadKeys(param.getKey(), param.getValue());
+            String[] values = param.getValue();
+            for (int i = 0; i < values.length; i++) {
+                try {
+                    values[i] = URLDecoder.decode(values[i], "UTF-8");
+                } catch (UnsupportedEncodingException ex) {
+
+                }
+            }
+            loadKeys(param.getKey(), values);
         }
     }
 

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -59,6 +59,16 @@ public class RequestTest {
     }
 
     @Test
+    public void queryParamShouldBeUrlDecoded() {
+        Map<String,String[]> params = new HashMap<String,String[]>();
+        params.put("user[name]",new String[] {"Federico%20With%20Blanks"});
+        HttpServletRequest servletRequest = new MockedHttpServletRequest(params);
+        Request request = new Request(match,servletRequest);
+        String name = request.queryMap("user").value("name");
+        assertEquals("Invalid name in query string","Federico With Blanks",name);
+    }
+
+    @Test
     public void shouldBeAbleToGetTheServletPath() {
         HttpServletRequest servletRequest = new MockedHttpServletRequest(new HashMap<String, String[]>()) {
             @Override


### PR DESCRIPTION
As per the current doc in QueryParamsMap I would expect QueryParamsMap values to be URL-Decoded but this isn't actually happening. A test to demonstrate this has been added and a patch is here to resolve the issue.