### PR TITLE
Use SNAPSHOT versions for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: java
+
 jdk:
   - oraclejdk8
 
+after_success:
+    - sh deploy/deploy-snapshot.sh
 
+env:
+    global:
+        - secure: "CHANGEME by the token generated with: travis encrypt CI_DEPLOY_USERNAME=your-sonatype-username"
+        - secure: "CHANGEME by the token generated with: travis encrypt CI_DEPLOY_PASSWORD=your-sonatype-password"

--- a/deploy/deploy-snapshot.sh
+++ b/deploy/deploy-snapshot.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Deploy a jar, source jar, and javadoc jar to Sonatype's snapshot repo.
+#
+# Inspired by: https://github.com/square/okhttp
+
+# In case we support more than one JDK versions, this is the one to be used
+# when deploying the SNAPSHOTs
+JDK="oraclejdk8"
+# Only publish SNAPSHOTS from this branch
+BRANCH="master"
+
+set -e
+
+if [ "$TRAVIS_JDK_VERSION" != "$JDK" ]; then
+  echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$TRAVIS_JDK_VERSION'."
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Skipping snapshot deployment: was pull request."
+elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
+  echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
+else
+  echo "Deploying snapshot..."
+  mvn clean source:jar javadoc:jar deploy --settings="deploy/settings.xml" -Dmaven.test.skip=true
+  echo "Snapshot deployed!"
+fi

--- a/deploy/settings.xml
+++ b/deploy/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+    <servers>
+        <server>
+            <id>sonatype-nexus-snapshots</id>
+            <username>${env.CI_DEPLOY_USERNAME}</username>
+            <password>${env.CI_DEPLOY_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
     <packaging>bundle</packaging>
-    <version>2.2</version>
+    <version>2.3-SNAPSHOT</version>
     <name>Spark</name>
     <description>A Sinatra inspired java web framework</description>
     <url>http://www.sparkjava.com</url>


### PR DESCRIPTION
This PR configures the project to use SNAPSHOTS for development, and is split in two commits:

* First commit configures the SNAPSHOT version.
* The second one configures the TravisCI build to deploy the master branch to the Sonatype snapshots repository for each successful build. This way you don't have to care about them and the latest SNAPSHOT will always be available.

In order to use the automatic snapshot deployment, you'll have to change the placeholder for the "secure" variables by the corresponding encrypted variable. You can generate them by running:

```bash
travis encrypt CI_DEPLOY_USERNAME=your-sonatype-username
travis encrypt CI_DEPLOY_PASSWORD=your-sonatype-password
```

See: http://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables