### PR TITLE
Add null check when Accept-Encoding header is empty.

### DIFF
--- a/src/main/java/spark/utils/GzipUtils.java
+++ b/src/main/java/spark/utils/GzipUtils.java
@@ -76,6 +76,10 @@ public class GzipUtils {
     private static class StringMatch implements Predicate<String> {
         @Override
         public boolean test(String s) {
+            if (s == null) {
+                return false;
+            }
+
             return s.contains(GZIP);
         }
     }


### PR DESCRIPTION
Long story short...  This patches a possible NPE when the Accept-Encoding header is empty.

On a simple Hello World server with ```get("/", (request, response) -> "Hello World");``` try the following:

curl http://localhost:4567  <=== works fine
curl -H "Accept-Encoding;" -v http://localhost:4567   <=== NPE

There were other ways to fix the error (check if there is even an accept encoding header available etc. ) but this was the easiest.