### PR TITLE
Add @FunctionalInterface to Spark's functional interfaces in its API

### DIFF
--- a/src/main/java/spark/ExceptionHandler.java
+++ b/src/main/java/spark/ExceptionHandler.java
@@ -3,6 +3,7 @@ package spark;
 /**
  * Created by Per Wendel on 2014-05-10.
  */
+@FunctionalInterface
 public interface ExceptionHandler {
 
     /**

--- a/src/main/java/spark/Filter.java
+++ b/src/main/java/spark/Filter.java
@@ -3,6 +3,7 @@ package spark;
 /**
  * Created by Per Wendel on 2014-05-10.
  */
+@FunctionalInterface
 public interface Filter {
 
     /**

--- a/src/main/java/spark/ResponseTransformer.java
+++ b/src/main/java/spark/ResponseTransformer.java
@@ -21,6 +21,7 @@ package spark;
  *
  * @author alex
  */
+@FunctionalInterface
 public interface ResponseTransformer {
 
     /**

--- a/src/main/java/spark/Route.java
+++ b/src/main/java/spark/Route.java
@@ -3,6 +3,7 @@ package spark;
 /**
  * Created by Per Wendel on 2014-05-10.
  */
+@FunctionalInterface
 public interface Route {
 
     /**

--- a/src/main/java/spark/TemplateViewRoute.java
+++ b/src/main/java/spark/TemplateViewRoute.java
@@ -25,6 +25,7 @@ package spark;
  *
  * @author alex
  */
+@FunctionalInterface
 public interface TemplateViewRoute {
 
     /**


### PR DESCRIPTION
The java annotation `@FunctionalInterface` is an informal annotation type,  to indicate that an interface type declaration is intended to be a functional interface as defined by the Java Language Specification.

With this annotation the compiler will throw an error, if this interface is changed in a way which would breaking existing Lambda usages etc.

Upon studying the Sparks API I was stumbling over compiler errors and was missing these annotations as a reassuring documentation.