### PR TITLE
fix route missing when an exception thrown

### DIFF
--- a/src/test/java/spark/ExceptionHandlerIntegrationTest.java
+++ b/src/test/java/spark/ExceptionHandlerIntegrationTest.java
@@ -1,0 +1,63 @@
+package spark;
+
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.Response;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+
+import static org.junit.Assert.assertEquals;
+import static spark.Spark.exception;
+import static spark.Spark.get;
+
+/**
+ * @author Tradunsky V.V.
+ */
+public class ExceptionHandlerIntegrationTest {
+    private static final String THROW_AN_EXCEPTION_ROUTE = "/throw";
+    private static final String EXCEPTION_BODY_MESSAGE = "It's bad idea";
+    private static final String GOOD_ROUTE = "/good";
+    private static final String GOOD_BODY_MESSAGE = "Something good";
+
+    private static SparkTestUtil testUtil;
+
+    @BeforeClass
+    public static void initRoutes() throws InterruptedException {
+        testUtil = new SparkTestUtil(4567);
+        exception(IllegalArgumentException.class,
+                (exception, request, response) -> {
+                    response.status(Response.SC_BAD_REQUEST);
+                    response.body(EXCEPTION_BODY_MESSAGE);
+                });
+        get(THROW_AN_EXCEPTION_ROUTE, (request, response) -> {
+            throw new IllegalArgumentException();
+        });
+
+        get(GOOD_ROUTE, (request, response) -> GOOD_BODY_MESSAGE);
+
+        try {
+            Thread.sleep(500);
+        } catch (Exception e) {
+        }
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        Spark.stop();
+    }
+
+    @Test
+    public void shouldHandleAnException() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), THROW_AN_EXCEPTION_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_BAD_REQUEST, response.status);
+        assertEquals("Should handle a body of response", EXCEPTION_BODY_MESSAGE, response.body);
+    }
+
+    @Test
+    public void shouldHandleARoute() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), GOOD_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_OK, response.status);
+        assertEquals("Should handle a body of response", GOOD_BODY_MESSAGE, response.body);
+    }
+}


### PR DESCRIPTION
Fix following use case:

```java
exception(IllegalArgumentException.class,(exception, request, response) -> {
                    response.status(Response.SC_BAD_REQUEST);
                    response.body("It's bad idea");
                });

get("/throw", (request, response) -> {
            throw new IllegalArgumentException();
});
```

Expected: 
Response code: 400
Response body: "It's bad idea"

Actual:
Response code: 404
Response body: "<html><body><h2>404 Not found</h2></body></html>"