### PR TITLE
Disabling inputStream cache when Transfer-Encoding=chunked

### DIFF
--- a/src/main/java/spark/webserver/JettyHandler.java
+++ b/src/main/java/spark/webserver/JettyHandler.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.http.protocol.HTTP;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.log.Log;
@@ -80,8 +79,8 @@ public class JettyHandler extends SessionHandler {
 
         @Override
         public ServletInputStream getInputStream() throws IOException {
-        	final String transferEncoding = _getHttpServletRequest().getHeader(HTTP.TRANSFER_ENCODING);
-        	if (HTTP.CHUNK_CODING.equals(transferEncoding)) {
+        	final String transferEncoding = _getHttpServletRequest().getHeader("Transfer-Encoding");
+        	if ("chunked".equals(transferEncoding)) {
         		// disable stream cache for chuncked transfer encoding
         		return super.getInputStream();
         	}

--- a/src/main/java/spark/webserver/JettyHandler.java
+++ b/src/main/java/spark/webserver/JettyHandler.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.protocol.HTTP;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.util.log.Log;
@@ -72,9 +73,19 @@ public class JettyHandler extends SessionHandler {
         public HttpRequestWrapper(HttpServletRequest request) {
             super(request);
         }
+        
+        private HttpServletRequest _getHttpServletRequest() {
+            return (HttpServletRequest) super.getRequest();
+        }
 
         @Override
         public ServletInputStream getInputStream() throws IOException {
+        	final String transferEncoding = _getHttpServletRequest().getHeader(HTTP.TRANSFER_ENCODING);
+        	if (HTTP.CHUNK_CODING.equals(transferEncoding)) {
+        		// disable stream cache for chuncked transfer encoding
+        		return super.getInputStream();
+        	}
+        	
             if (cachedBytes == null) {
                 cacheInputStream();
             }


### PR DESCRIPTION
The current implementation for the HttpServletRequest returned from request.raw() (HttpRequestWrapper.class) caches the bytes when getInputStream() is called. When large data is transfered, an OutOfMemoryError is thrown, even when using chunked transfer encoding.
