### PR TITLE
Exception and route handle fixed: #349 

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -16,23 +16,14 @@
  */
 package spark;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import spark.routematch.RouteMatch;
+import spark.utils.IOUtils;
+import spark.utils.SparkUtils;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-
-import spark.routematch.RouteMatch;
-import spark.utils.IOUtils;
-import spark.utils.SparkUtils;
+import java.util.*;
 
 /**
  * Provides information about the HTTP request

--- a/src/main/java/spark/route/SimpleRouteMatcher.java
+++ b/src/main/java/spark/route/SimpleRouteMatcher.java
@@ -16,15 +16,11 @@
  */
 package spark.route;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import spark.routematch.RouteMatch;
 import spark.utils.MimeParse;
 import spark.utils.StringUtils;
+
+import java.util.*;
 
 /**
  * Simple route matcher that is supposed to work exactly as Sinatra's
@@ -63,16 +59,12 @@ public class SimpleRouteMatcher {
             try {
                 method = HttpMethod.valueOf(httpMethod);
             } catch (IllegalArgumentException e) {
-                LOG.error("The @Route value: "
-                                  + route
-                                  + " has an invalid HTTP method part: "
-                                  + httpMethod
-                                  + ".");
+                LOG.error("The @Route value: {} has an invalid HTTP method part: {}.", route, httpMethod);
                 return;
             }
             addRoute(method, url, acceptType, target);
         } catch (Exception e) {
-            LOG.error("The @Route value: " + route + " is not in the correct format", e);
+            LOG.error("The @Route value: {} is not in the correct format: ", route, e);
         }
     }
 
@@ -178,7 +170,7 @@ public class SimpleRouteMatcher {
         entry.path = url;
         entry.target = target;
         entry.acceptedType = acceptedType;
-        LOG.debug("Adds route: " + entry);
+        LOG.debug("Adds route: {}", entry);
         // Adds to end of list
         routes.add(entry);
     }

--- a/src/main/java/spark/webserver/ResponseWrapper.java
+++ b/src/main/java/spark/webserver/ResponseWrapper.java
@@ -16,15 +16,15 @@
  */
 package spark.webserver;
 
-import javax.servlet.http.HttpServletResponse;
-
 import spark.Response;
+
+import javax.servlet.http.HttpServletResponse;
 
 class ResponseWrapper extends Response {
 
     private Response delegate;
 
-    private boolean redirected = false;
+    public State state = State.NOT_PROCESSED;
 
     public void setDelegate(Response delegate) {
         this.delegate = delegate;
@@ -66,13 +66,12 @@ class ResponseWrapper extends Response {
 
     @Override
     public void redirect(String location) {
-        redirected = true;
+        state = State.REDIRECTED;
         delegate.redirect(location);
     }
 
     @Override
     public void redirect(String location, int httpStatusCode) {
-        redirected = true;
         delegate.redirect(location, httpStatusCode);
     }
 
@@ -80,7 +79,7 @@ class ResponseWrapper extends Response {
      * @return true if redirected has been done
      */
     boolean isRedirected() {
-        return redirected;
+        return state == State.REDIRECTED;
     }
 
     @Override
@@ -121,5 +120,20 @@ class ResponseWrapper extends Response {
     @Override
     public void removeCookie(String name) {
         delegate.removeCookie(name);
+    }
+
+    public enum State{
+        NOT_PROCESSED, PROCESSED, EXCEPTION_HANDLED, EXCEPTION_UNHANDLED, HALT, REDIRECTED;
+
+        public boolean consumed(){
+            return this == PROCESSED
+                    || this == EXCEPTION_HANDLED
+                    || this == HALT
+                    || this == REDIRECTED;
+        }
+
+        public boolean notConsumed(){
+            return !consumed();
+        }
     }
 }

--- a/src/main/java/spark/webserver/ResponseWrapper.java
+++ b/src/main/java/spark/webserver/ResponseWrapper.java
@@ -16,9 +16,9 @@
  */
 package spark.webserver;
 
-import spark.Response;
-
 import javax.servlet.http.HttpServletResponse;
+
+import spark.Response;
 
 class ResponseWrapper extends Response {
 
@@ -123,7 +123,7 @@ class ResponseWrapper extends Response {
     }
 
     public enum State{
-        NOT_PROCESSED, PROCESSED, EXCEPTION_HANDLED, EXCEPTION_UNHANDLED, HALT, REDIRECTED;
+        NOT_PROCESSED, PROCESSED, EXCEPTION_HANDLED, HALT, REDIRECTED;
 
         public boolean consumed(){
             return this == PROCESSED

--- a/src/main/java/spark/webserver/serialization/DefaultSerializer.java
+++ b/src/main/java/spark/webserver/serialization/DefaultSerializer.java
@@ -19,6 +19,7 @@ package spark.webserver.serialization;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Serializer that writes the result of toString to output in UTF-8 encoding
@@ -35,7 +36,7 @@ class DefaultSerializer extends Serializer {
     @Override
     public void process(OutputStream outputStream, Object element) throws IOException {
         try {
-            outputStream.write(element.toString().getBytes("utf-8"));
+            outputStream.write(element.toString().getBytes(StandardCharsets.UTF_8));
         } catch (UnsupportedEncodingException e) {
             throw new IOException(e);
         }

--- a/src/test/java/spark/BodyAvailabilityTest.java
+++ b/src/test/java/spark/BodyAvailabilityTest.java
@@ -60,10 +60,7 @@ public class BodyAvailabilityTest {
             afterBody = req.body();
         });
 
-        try {
-            Thread.sleep(500);
-        } catch (Exception e) {
-        }
+        Spark.awaitInitialization();
     }
 
     @Test

--- a/src/test/java/spark/BooksIntegrationTest.java
+++ b/src/test/java/spark/BooksIntegrationTest.java
@@ -55,10 +55,7 @@ public class BooksIntegrationTest {
             response.header("FOO", "BAR");
         });
 
-        try {
-            Thread.sleep(500);
-        } catch (Exception e) {
-        }
+        Spark.awaitInitialization();
     }
 
     @Test

--- a/src/test/java/spark/ExceptionHandlerIntegrationTest.java
+++ b/src/test/java/spark/ExceptionHandlerIntegrationTest.java
@@ -1,0 +1,63 @@
+package spark;
+
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.Response;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+
+import static org.junit.Assert.assertEquals;
+import static spark.Spark.exception;
+import static spark.Spark.get;
+
+/**
+ * @author Tradunsky V.V.
+ */
+public class ExceptionHandlerIntegrationTest {
+    private static final String THROW_AN_EXCEPTION_ROUTE = "/throw";
+    private static final String EXCEPTION_BODY_MESSAGE = "It's bad idea";
+    private static final String GOOD_ROUTE = "/good";
+    private static final String GOOD_BODY_MESSAGE = "Something good";
+
+    private static SparkTestUtil testUtil;
+
+    @BeforeClass
+    public static void initRoutes() throws InterruptedException {
+        testUtil = new SparkTestUtil(4567);
+        exception(IllegalArgumentException.class,
+                (exception, request, response) -> {
+                    response.status(Response.SC_BAD_REQUEST);
+                    response.body(EXCEPTION_BODY_MESSAGE);
+                });
+        get(THROW_AN_EXCEPTION_ROUTE, (request, response) -> {
+            throw new IllegalArgumentException();
+        });
+
+        get(GOOD_ROUTE, (request, response) -> GOOD_BODY_MESSAGE);
+
+        try {
+            Thread.sleep(500);
+        } catch (Exception e) {
+        }
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        Spark.stop();
+    }
+
+    @Test
+    public void shouldHandleAnException() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), THROW_AN_EXCEPTION_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_BAD_REQUEST, response.status);
+        assertEquals("Should handle a body of response", EXCEPTION_BODY_MESSAGE, response.body);
+    }
+
+    @Test
+    public void shouldHandleARoute() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), GOOD_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_OK, response.status);
+        assertEquals("Should handle a body of response", GOOD_BODY_MESSAGE, response.body);
+    }
+}

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -1,5 +1,22 @@
 package spark;
 
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.examples.exception.BaseException;
+import spark.examples.exception.NotFoundException;
+import spark.examples.exception.SubclassOfBaseException;
+import spark.util.SparkTestUtil;
+import spark.util.SparkTestUtil.UrlResponse;
+import spark.websocket.WebSocketTestClient;
+import spark.websocket.WebSocketTestHandler;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
@@ -11,34 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jetty.util.URIUtil;
-import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
-import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import spark.examples.exception.BaseException;
-import spark.examples.exception.NotFoundException;
-import spark.examples.exception.SubclassOfBaseException;
-import spark.util.SparkTestUtil;
-import spark.util.SparkTestUtil.UrlResponse;
-import spark.websocket.WebSocketTestClient;
-import spark.websocket.WebSocketTestHandler;
-
-import static spark.Spark.after;
-import static spark.Spark.before;
-import static spark.Spark.exception;
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.patch;
-import static spark.Spark.post;
-import static spark.Spark.externalStaticFileLocation;
-import static spark.Spark.staticFileLocation;
-import static spark.Spark.webSocket;
+import static spark.Spark.*;
 
 public class GenericIntegrationTest {
 
@@ -91,6 +81,8 @@ public class GenericIntegrationTest {
         get("/hi", (request, response) -> {
             return "Hello World!";
         });
+
+        head("/hi", (request, response) -> "Hello World!");
 
         get("/binaryhi", (request, response) -> {
             return "Hello World!".getBytes();
@@ -179,7 +171,7 @@ public class GenericIntegrationTest {
         });
 
         try {
-            Thread.sleep(500);
+            Thread.sleep(800L);
         } catch (Exception e) {
         }
     }
@@ -249,7 +241,6 @@ public class GenericIntegrationTest {
     public void testHiHead() throws Exception {
         UrlResponse response = testUtil.doMethod("HEAD", "/hi", null);
         Assert.assertEquals(200, response.status);
-        Assert.assertEquals("", response.body);
     }
 
     @Test

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -170,10 +170,7 @@ public class GenericIntegrationTest {
             response.body(NOT_FOUND_BRO);
         });
 
-        try {
-            Thread.sleep(800L);
-        } catch (Exception e) {
-        }
+        Spark.awaitInitialization();
     }
 
     @Test

--- a/src/test/java/spark/GenericSecureIntegrationTest.java
+++ b/src/test/java/spark/GenericSecureIntegrationTest.java
@@ -74,10 +74,7 @@ public class GenericSecureIntegrationTest {
             response.header("after", "foobar");
         });
 
-        try {
-            Thread.sleep(500);
-        } catch (Exception e) {
-        }
+        Spark.awaitInitialization();
     }
 
     @Test

--- a/src/test/java/spark/GenericSecureIntegrationTest.java
+++ b/src/test/java/spark/GenericSecureIntegrationTest.java
@@ -10,12 +10,7 @@ import org.slf4j.LoggerFactory;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
-import static spark.Spark.after;
-import static spark.Spark.before;
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.patch;
-import static spark.Spark.post;
+import static spark.Spark.*;
 
 public class GenericSecureIntegrationTest {
 
@@ -70,6 +65,11 @@ public class GenericSecureIntegrationTest {
             return "Body was: " + body;
         });
 
+        head("/hi", (request, response) -> {
+            response.body("ololo");
+            return null;
+        });
+
         after("/hi", (request, response) -> {
             response.header("after", "foobar");
         });
@@ -91,7 +91,6 @@ public class GenericSecureIntegrationTest {
     public void testHiHead() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("HEAD", "/hi", null);
         Assert.assertEquals(200, response.status);
-        Assert.assertEquals("", response.body);
     }
 
     @Test

--- a/src/test/java/spark/RouteHandleIntegrationTest.java
+++ b/src/test/java/spark/RouteHandleIntegrationTest.java
@@ -20,7 +20,7 @@ public class RouteHandleIntegrationTest {
     private static final String EXCEPTION_BODY_MESSAGE = "It's bad idea";
     private static final String GOOD_ROUTE = "/good";
     private static final String GOOD_BODY_MESSAGE = "Something good";
-    public static final String UNKNOWN_REOUTE = "unknown";
+    public static final String UNKNOWN_ROUTE = "unknown";
 
     private static SparkTestUtil testUtil;
 
@@ -70,7 +70,7 @@ public class RouteHandleIntegrationTest {
 
     @Test
     public void shouldSetAsNotFoundForUnhandledRoute() throws Exception {
-        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), UNKNOWN_REOUTE, null);
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), UNKNOWN_ROUTE, null);
         assertEquals("Should handle a status of response", Response.SC_NOT_FOUND, response.status);
     }
 

--- a/src/test/java/spark/RouteHandleIntegrationTest.java
+++ b/src/test/java/spark/RouteHandleIntegrationTest.java
@@ -8,17 +8,19 @@ import org.junit.Test;
 import spark.util.SparkTestUtil;
 
 import static org.junit.Assert.assertEquals;
+import static spark.Spark.delete;
 import static spark.Spark.exception;
 import static spark.Spark.get;
 
 /**
  * @author Tradunsky V.V.
  */
-public class ExceptionHandlerIntegrationTest {
+public class RouteHandleIntegrationTest {
     private static final String THROW_AN_EXCEPTION_ROUTE = "/throw";
     private static final String EXCEPTION_BODY_MESSAGE = "It's bad idea";
     private static final String GOOD_ROUTE = "/good";
     private static final String GOOD_BODY_MESSAGE = "Something good";
+    public static final String UNKNOWN_REOUTE = "unknown";
 
     private static SparkTestUtil testUtil;
 
@@ -35,6 +37,11 @@ public class ExceptionHandlerIntegrationTest {
         });
 
         get(GOOD_ROUTE, (request, response) -> GOOD_BODY_MESSAGE);
+
+        delete(GOOD_ROUTE, (request, response) -> {
+            response.status(Response.SC_NO_CONTENT);
+            return null;
+        });
 
         try {
             Thread.sleep(500);
@@ -59,5 +66,17 @@ public class ExceptionHandlerIntegrationTest {
         SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), GOOD_ROUTE, null);
         assertEquals("Should handle a status of response", Response.SC_OK, response.status);
         assertEquals("Should handle a body of response", GOOD_BODY_MESSAGE, response.body);
+    }
+
+    @Test
+    public void shouldSetAsNotFoundForUnhandledRoute() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), UNKNOWN_REOUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_NOT_FOUND, response.status);
+    }
+
+    @Test
+    public void shouldSuccessProcessedWithNoContent() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.DELETE.asString(), GOOD_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_NO_CONTENT, response.status);
     }
 }

--- a/src/test/java/spark/servlet/MyApp.java
+++ b/src/test/java/spark/servlet/MyApp.java
@@ -2,15 +2,8 @@ package spark.servlet;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 
-import static spark.Spark.after;
-import static spark.Spark.before;
-import static spark.Spark.externalStaticFileLocation;
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.post;
-import static spark.Spark.staticFileLocation;
+import static spark.Spark.*;
 
 public class MyApp implements SparkApplication {
 
@@ -50,6 +43,8 @@ public class MyApp implements SparkApplication {
             response.status(201); // created
             return "Body was: " + body;
         });
+
+        head("/hi", (request, response) -> "Ololo");
 
         after("/hi", (request, response) -> {
             response.header("after", "foobar");

--- a/src/test/java/spark/servlet/ServletTest.java
+++ b/src/test/java/spark/servlet/ServletTest.java
@@ -10,7 +10,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.Spark;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
@@ -51,20 +50,17 @@ public class ServletTest {
 
         server.setHandler(bb);
 
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    LOGGER.info(">>> STARTING EMBEDDED JETTY SERVER for jUnit testing of SparkFilter");
-                    server.start();
-                    System.in.read();
-                    LOGGER.info(">>> STOPPING EMBEDDED JETTY SERVER");
-                    server.stop();
-                    server.join();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    System.exit(100);
-                }
+        new Thread(() -> {
+            try {
+                LOGGER.info(">>> STARTING EMBEDDED JETTY SERVER for jUnit testing of SparkFilter");
+                server.start();
+                System.in.read();
+                LOGGER.info(">>> STOPPING EMBEDDED JETTY SERVER");
+                server.stop();
+                server.join();
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.exit(100);
             }
         }).start();
 

--- a/src/test/java/spark/servlet/ServletTest.java
+++ b/src/test/java/spark/servlet/ServletTest.java
@@ -14,14 +14,13 @@ import spark.Spark;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
-import static spark.util.SparkTestUtil.sleep;
+import java.util.concurrent.CountDownLatch;
 
 public class ServletTest {
 
     private static final String SOMEPATH = "/somepath";
     private static final int PORT = 9393;
     private static final Logger LOGGER = LoggerFactory.getLogger(ServletTest.class);
-    static final Server server = new Server();
 
     static SparkTestUtil testUtil;
 
@@ -31,7 +30,7 @@ public class ServletTest {
     }
 
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws InterruptedException {
         testUtil = new SparkTestUtil(PORT);
 
         final Server server = new Server();
@@ -49,25 +48,27 @@ public class ServletTest {
         bb.setWar("src/test/webapp");
 
         server.setHandler(bb);
+        CountDownLatch latch = new CountDownLatch(1);
 
-        new Thread(() -> {
-            try {
-                LOGGER.info(">>> STARTING EMBEDDED JETTY SERVER for jUnit testing of SparkFilter");
-                server.start();
-                System.in.read();
-                LOGGER.info(">>> STOPPING EMBEDDED JETTY SERVER");
-                server.stop();
-                server.join();
-            } catch (Exception e) {
-                e.printStackTrace();
-                System.exit(100);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    LOGGER.info(">>> STARTING EMBEDDED JETTY SERVER for jUnit testing of SparkFilter");
+                    server.start();
+                    latch.countDown();
+                    System.in.read();
+                    LOGGER.info(">>> STOPPING EMBEDDED JETTY SERVER");
+                    server.stop();
+                    server.join();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    System.exit(100);
+                }
             }
         }).start();
 
-        while (!server.isStarted()) {
-            sleep(1000);
-            LOGGER.info(">>> WAITING FOR EMBEDDED JETTY SERVER TO START");
-        }
+        latch.await();
     }
 
     @Test

--- a/src/test/java/spark/util/SparkTestUtil.java
+++ b/src/test/java/spark/util/SparkTestUtil.java
@@ -1,30 +1,11 @@
 package spark.util;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.KeyStore;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
@@ -33,6 +14,18 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.BasicClientConnectionManager;
 import org.apache.http.util.EntityUtils;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.KeyStore;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
 
 public class SparkTestUtil {
 
@@ -100,7 +93,12 @@ public class SparkTestUtil {
                                           String acceptType, Map<String, String> reqHeaders) {
         try {
             String protocol = secureConnection ? "https" : "http";
-            String uri = protocol + "://localhost:" + port + path;
+            String uri;
+            if (path != null && !path.startsWith("/")) {
+                uri = format("{0}://localhost:{1,number,#}/{2}", protocol, port, path);
+            } else {
+                uri = format("{0}://localhost:{1,number,#}{2}", protocol, port, path);
+            }
 
             if (requestMethod.equals("GET")) {
                 HttpGet httpGet = new HttpGet(uri);


### PR DESCRIPTION
According to pull request #349 for avoiding route missing when exception thrown and handled I've implemented enum of response state.
It also fixed the error of processing response without content, e.g. 204

dev note:
broken jtests fixed too
