### PR TITLE
copy stream directly rather than buffer as a utf-8 string

### DIFF
--- a/src/main/java/spark/webserver/serialization/InputStreamSerializer.java
+++ b/src/main/java/spark/webserver/serialization/InputStreamSerializer.java
@@ -37,8 +37,7 @@ class InputStreamSerializer extends Serializer {
     @Override
     public void process(OutputStream outputStream, Object element)
             throws IOException {
-        String content = IOUtils.toString((InputStream) element);
-        outputStream.write(content.getBytes("utf-8"));
+        IOUtils.copy((InputStream) element, outputStream);
     }
 
 }


### PR DESCRIPTION
Hi Per,

This change copies a returned InputStream directly to output rather than read it in to memory first.  The InputStream might be large (making buffering a problem) and might not be valid UTF-8 (e.g. could be arbitrary data returned as application/octet-stream).