### PR TITLE
Do not force a logging implementation by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,6 @@
             <version>1.7.12</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.12</version>
-        </dependency>
-
         <!-- JETTY DEPENDENCIES -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Spark is used in applications as a dependency and should not preconfigure the logging framework to be used. It should be up to the applications to pick their preferred SLF4J implementation without having to exclude the Spark's default impl when declaring the Spark dependency.