### PR TITLE
Moved slf4j-simple to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.12</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- JETTY DEPENDENCIES -->


### PR DESCRIPTION
Most users of the framework will BYOL (Bring Your Own Logger).
Having SLF4J-SIMPLE just causes a headache since they would need
to explicitly remove that as a transitive dependency.

Moving it to the test scope resolves this problem.