### PR TITLE
Make SparkInstance and Routable public.

### DIFF
--- a/src/main/java/spark/Routable.java
+++ b/src/main/java/spark/Routable.java
@@ -22,7 +22,7 @@ import spark.utils.SparkUtils;
 /**
  * Routable abstract class. Lets extending classes inherit default routable functionality.
  */
-abstract class Routable {
+public abstract class Routable {
 
     /**
      * Adds a route

--- a/src/main/java/spark/SparkInstance.java
+++ b/src/main/java/spark/SparkInstance.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Holds the implementation of the Spark API. (previously in Spark and SparkBase).
  */
-final class SparkInstance extends Routable {
+public final class SparkInstance extends Routable {
     private static final Logger LOG = LoggerFactory.getLogger("spark.Spark");
 
     public static final int SPARK_DEFAULT_PORT = 4567;


### PR DESCRIPTION
Hi I just wanted to submit this PR is a means to talk about being able to control the initialisation of spark when using DI. I'm not strong on Java API design so maybe making these public is the wrong way to go about it. Anyway feedback is welcome.

If this is something that might be committable, I would add examples and possibly tests.

It would let us do something like below. 

```java
public abstract class ViewRoute eextends Routable {
    private SparkInstance instance
    public ViewRoute(SparkInstance instance) {
        this.instance = instance;
    }

    @Override
    public void addRoute(String httpMethod, RouteImpl route) {
        instance.addRouter(httpMethod, route);
    }

    @Override
    public void addFilter(String httpMethod, FilterImpl filter) {
       instance.addFilter(httpMethod, filter);
    }
}

@Singleton
public class LoginRoute extends ViewRoute {    
    @Inject
    public LoginRoute(SparkInstance instance) {
       super(instance);

       get("/login", (request, response) --> ....);
   }
}
```