### PR TITLE
Code quality fix - Lazy initialization of static fields should be synchronized

### DIFF
--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -30,7 +30,7 @@ public class ExceptionMapper {
      *
      * @return Default instance
      */
-    public static ExceptionMapper getInstance() {
+    public synchronized static ExceptionMapper getInstance() {
         if (defaultInstance == null) {
             defaultInstance = new ExceptionMapper();
         }

--- a/src/main/java/spark/staticfiles/StaticFiles.java
+++ b/src/main/java/spark/staticfiles/StaticFiles.java
@@ -83,7 +83,7 @@ public class StaticFiles {
      *
      * @param folder the location
      */
-    public static void configureStaticResources(String folder) {
+    public synchronized static void configureStaticResources(String folder) {
         Assert.notNull(folder, "'folder' must not be null");
 
         if (!staticResourcesSet) {
@@ -112,7 +112,7 @@ public class StaticFiles {
      *
      * @param folder the location
      */
-    public static void configureExternalStaticResources(String folder) {
+    public synchronized static void configureExternalStaticResources(String folder) {
         Assert.notNull(folder, "'folder' must not be null");
 
         if (!externalStaticResourcesSet) {

--- a/src/test/java/spark/servlet/MyApp.java
+++ b/src/test/java/spark/servlet/MyApp.java
@@ -18,7 +18,7 @@ public class MyApp implements SparkApplication {
     static File tmpExternalFile;
 
     @Override
-    public void init() {
+    public synchronized void init() {
         try {
             externalStaticFileLocation(System.getProperty("java.io.tmpdir"));
             staticFileLocation("/public");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 “Lazy initialization of static fields should be synchronized”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2444

Please let me know if you have any questions.

Faisal.