### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/spark/route/RouteEntry.java
+++ b/src/main/java/spark/route/RouteEntry.java
@@ -51,14 +51,14 @@ class RouteEntry {
                 String thisPathPart = thisPathList.get(i);
                 String pathPart = pathList.get(i);
 
-                if ((i == thisPathSize - 1) && (thisPathPart.equals("*") && this.path.endsWith("*"))) {
+                if ((i == thisPathSize - 1) && ("*".equals(thisPathPart) && this.path.endsWith("*"))) {
                     // wildcard match
                     return true;
                 }
 
-                if ((!thisPathPart.startsWith(":"))
-                        && !thisPathPart.equals(pathPart)
-                        && !thisPathPart.equals("*")) {
+                if (!"*".equals(thisPathPart)
+                        && (!thisPathPart.startsWith(":"))
+                        && !thisPathPart.equals(pathPart)) {
                     return false;
                 }
             }
@@ -79,13 +79,13 @@ class RouteEntry {
                     for (int i = 0; i < thisPathSize; i++) {
                         String thisPathPart = thisPathList.get(i);
                         String pathPart = pathList.get(i);
-                        if (thisPathPart.equals("*") && (i == thisPathSize - 1) && this.path.endsWith("*")) {
+                        if ("*".equals(thisPathPart) && (i == thisPathSize - 1) && this.path.endsWith("*")) {
                             // wildcard match
                             return true;
                         }
-                        if (!thisPathPart.startsWith(":")
-                                && !thisPathPart.equals(pathPart)
-                                && !thisPathPart.equals("*")) {
+                        if (!"*".equals(thisPathPart)
+                                && !thisPathPart.startsWith(":")
+                                && !thisPathPart.equals(pathPart)) {
                             return false;
                         }
                     }

--- a/src/main/java/spark/utils/MimeParse.java
+++ b/src/main/java/spark/utils/MimeParse.java
@@ -60,7 +60,7 @@ public class MimeParse {
 
         // Java URLConnection class sends an Accept header that includes a
         // single "*" - Turn it into a legal wildcard.
-        if (fullType.equals("*")) {
+        if ("*".equals(fullType)) {
             fullType = "*/*";
         }
 
@@ -141,12 +141,12 @@ public class MimeParse {
         ParseResults target = parseMediaRange(mimeType);
 
         for (ParseResults range : parsedRanges) {
-            if ((target.type.equals(range.type) || range.type.equals("*") || target.type.equals("*"))
-                    && (target.subType.equals(range.subType) || range.subType.equals("*")
-                    || target.subType.equals("*"))) {
+            if ((target.type.equals(range.type) || "*".equals(range.type) || "*".equals(target.type))
+                    && (target.subType.equals(range.subType) || "*".equals(range.subType)
+                    || "*".equals(target.subType))) {
                 for (String k : target.params.keySet()) {
                     int paramMatches = 0;
-                    if (!k.equals("q") && range.params.containsKey(k)
+                    if (!"q".equals(k) && range.params.containsKey(k)
                             && target.params.get(k).equals(range.params.get(k))) {
                         paramMatches++;
                     }

--- a/src/main/java/spark/utils/SparkUtils.java
+++ b/src/main/java/spark/utils/SparkUtils.java
@@ -47,7 +47,7 @@ public final class SparkUtils {
     }
 
     public static boolean isSplat(String routePart) {
-        return routePart.equals("*");
+        return "*".equals(routePart);
     }
 
 }

--- a/src/test/java/spark/servlet/FilterConfigWrapper.java
+++ b/src/test/java/spark/servlet/FilterConfigWrapper.java
@@ -28,7 +28,7 @@ public class FilterConfigWrapper implements FilterConfig {
      * @see javax.servlet.FilterConfig#getInitParameter(java.lang.String)
      */
     public String getInitParameter(String name) {
-        if (name.equals("applicationClass")) {
+        if ("applicationClass".equals(name)) {
             return "spark.servlet.MyApp";
         }
         return delegate.getInitParameter(name);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal.