### PR TITLE
Fix route missing when exception thrown and handled/unhandled.

### DIFF
--- a/src/main/java/spark/webserver/MatcherFilter.java
+++ b/src/main/java/spark/webserver/MatcherFilter.java
@@ -147,6 +147,7 @@ public class MatcherFilter implements Filter {
             if (match != null) {
                 target = match.getTarget();
             } else if (httpMethod == HttpMethod.head && bodyContent == null) {
+                responseWrapper.changeStateTo(ResponseWrapper.State.PROCESSED);
                 // See if get is mapped to provide default head mapping
                 bodyContent =
                         routeMatcher.findTargetForRequestedRoute(HttpMethod.get, uri, acceptType) != null ? "" : null;
@@ -154,6 +155,7 @@ public class MatcherFilter implements Filter {
 
             if (target != null) {
                 try {
+                    responseWrapper.changeStateTo(ResponseWrapper.State.PROCESSED);
                     Object result = null;
                     if (target instanceof RouteImpl) {
                         RouteImpl route = ((RouteImpl) target);
@@ -209,49 +211,44 @@ public class MatcherFilter implements Filter {
 
         } catch (HaltException hEx) {
             LOG.debug("halt performed");
+            responseWrapper.changeStateTo(ResponseWrapper.State.HALT);
             httpResponse.setStatus(hEx.getStatusCode());
             if (hEx.getBody() != null) {
                 bodyContent = hEx.getBody();
-            } else {
-                bodyContent = "";
             }
         } catch (Exception e) {
             ExceptionHandlerImpl handler = ExceptionMapper.getInstance().getHandler(e);
             if (handler != null) {
                 handler.handle(e, requestWrapper, responseWrapper);
+                responseWrapper.changeStateTo(ResponseWrapper.State.EXCEPTION_HANDLED);
                 String bodyAfterFilter = Access.getBody(responseWrapper.getDelegate());
                 if (bodyAfterFilter != null) {
                     bodyContent = bodyAfterFilter;
                 }
             } else {
-                LOG.error("", e);
+                LOG.error("Unhandled error:", e);
+                responseWrapper.changeStateTo(ResponseWrapper.State.EXCEPTION_NOT_HANDLED);
                 httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 bodyContent = INTERNAL_ERROR;
             }
         }
 
-        // If redirected and content is null set to empty string to not throw NotConsumedException
-        if (bodyContent == null && responseWrapper.isRedirected()) {
-            bodyContent = "";
-        }
-
-        boolean consumed = bodyContent != null;
-
-        if (!consumed && hasOtherHandlers) {
+        if (responseWrapper.isNotPrepared() && hasOtherHandlers) {
             if (servletRequest instanceof HttpRequestWrapper) {
                 ((HttpRequestWrapper) servletRequest).notConsumed(true);
                 return;
             }
         }
 
-        if (!consumed && !isServletContext) {
-            LOG.info("The requested route [" + uri + "] has not been mapped in Spark");
+        if (responseWrapper.isNotInStateOf(ResponseWrapper.State.EXCEPTION_NOT_HANDLED)
+            && responseWrapper.isNotPrepared() && !isServletContext) {
+            LOG.info("The requested route {} [{}] has not been mapped in Spark",
+                     httpMethodStr.toUpperCase(), uri);
             httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            bodyContent = String.format(NOT_FOUND);
-            consumed = true;
+            bodyContent = NOT_FOUND;
         }
 
-        if (consumed) {
+        if (responseWrapper.isPrepared() && bodyContent != null) {
             // Write body content
             if (!httpResponse.isCommitted()) {
                 if (httpResponse.getContentType() == null) {

--- a/src/main/java/spark/webserver/ResponseWrapper.java
+++ b/src/main/java/spark/webserver/ResponseWrapper.java
@@ -24,7 +24,7 @@ class ResponseWrapper extends Response {
 
     private Response delegate;
 
-    private boolean redirected = false;
+    private State state = State.NOT_PROCESSED;
 
     public void setDelegate(Response delegate) {
         this.delegate = delegate;
@@ -66,13 +66,13 @@ class ResponseWrapper extends Response {
 
     @Override
     public void redirect(String location) {
-        redirected = true;
+        state = State.REDIRECTED;
         delegate.redirect(location);
     }
 
     @Override
     public void redirect(String location, int httpStatusCode) {
-        redirected = true;
+        state = State.REDIRECTED;
         delegate.redirect(location, httpStatusCode);
     }
 
@@ -80,7 +80,7 @@ class ResponseWrapper extends Response {
      * @return true if redirected has been done
      */
     boolean isRedirected() {
-        return redirected;
+        return state == State.REDIRECTED;
     }
 
     @Override
@@ -121,5 +121,43 @@ class ResponseWrapper extends Response {
     @Override
     public void removeCookie(String name) {
         delegate.removeCookie(name);
+    }
+
+    public void changeStateTo(State newState){
+        this.state = newState;
+    }
+
+    public boolean inStateOf(State possibleState){
+        return this.state == possibleState;
+    }
+
+    public boolean isNotInStateOf(State possibleState){
+        return this.state != possibleState;
+    }
+
+    public boolean isNotPrepared(){
+        return state.notPrepared();
+    }
+
+    public boolean isPrepared(){
+        return state.prepared();
+    }
+
+    public enum State{
+        NOT_PROCESSED, PROCESSED,
+        EXCEPTION_HANDLED, EXCEPTION_NOT_HANDLED,
+        HALT,
+        REDIRECTED;
+
+        public boolean prepared(){
+            return this == PROCESSED
+                    || this == EXCEPTION_HANDLED
+                    || this == HALT
+                    || this == REDIRECTED;
+        }
+
+        public boolean notPrepared(){
+            return !prepared();
+        }
     }
 }

--- a/src/test/java/spark/RouteHandleIntegrationTest.java
+++ b/src/test/java/spark/RouteHandleIntegrationTest.java
@@ -1,0 +1,91 @@
+package spark;
+
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.Response;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import spark.util.SparkTestUtil;
+
+import static org.junit.Assert.assertEquals;
+import static spark.Spark.delete;
+import static spark.Spark.exception;
+import static spark.Spark.get;
+
+/**
+ * @author Tradunsky V.V.
+ */
+public class RouteHandleIntegrationTest {
+    private static final String THROW_HANDLED_EXCEPTION_ROUTE = "/handled_throw";
+    private static final String THROW_UNHANDLED_EXCEPTION_ROUTE = "/unhandled_throw";
+    private static final String EXCEPTION_BODY_MESSAGE = "It's bad idea";
+    private static final String GOOD_ROUTE = "/good";
+    private static final String GOOD_BODY_MESSAGE = "Something good";
+    public static final String UNKNOWN_ROUTE = "unknown";
+
+    private static SparkTestUtil testUtil;
+
+    @BeforeClass
+    public static void initRoutes() throws InterruptedException {
+        testUtil = new SparkTestUtil(4567);
+        exception(IllegalArgumentException.class,
+                (exception, request, response) -> {
+                    response.status(Response.SC_BAD_REQUEST);
+                    response.body(EXCEPTION_BODY_MESSAGE);
+                });
+        get(THROW_HANDLED_EXCEPTION_ROUTE, (request, response) -> {
+            throw new IllegalArgumentException();
+        });
+
+        get(THROW_UNHANDLED_EXCEPTION_ROUTE, (request, response) -> {
+            throw new NullPointerException();
+        });
+
+        get(GOOD_ROUTE, (request, response) -> GOOD_BODY_MESSAGE);
+
+        delete(GOOD_ROUTE, (request, response) -> {
+            response.status(Response.SC_NO_CONTENT);
+            return null;
+        });
+
+        Spark.awaitInitialization();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        Spark.stop();
+    }
+
+    @Test
+    public void shouldHandleAnException() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), THROW_HANDLED_EXCEPTION_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_BAD_REQUEST, response.status);
+        assertEquals("Should handle a body of response", EXCEPTION_BODY_MESSAGE, response.body);
+    }
+
+    @Test
+    public void shouldHandleUnknownException() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), THROW_UNHANDLED_EXCEPTION_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_INTERNAL_SERVER_ERROR, response.status);
+    }
+
+    @Test
+    public void shouldHandleARoute() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), GOOD_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_OK, response.status);
+        assertEquals("Should handle a body of response", GOOD_BODY_MESSAGE, response.body);
+    }
+
+    @Test
+    public void shouldSetAsNotFoundForUnhandledRoute() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.GET.asString(), UNKNOWN_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_NOT_FOUND, response.status);
+    }
+
+    @Test
+    public void shouldSuccessProcessedWithNoContent() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod(HttpMethod.DELETE.asString(), GOOD_ROUTE, null);
+        assertEquals("Should handle a status of response", Response.SC_NO_CONTENT, response.status);
+    }
+}


### PR DESCRIPTION
It also fix the error of processing response without content, e.g. 204

According to Per's request (https://github.com/perwendel/spark/pull/352#issuecomment-149323246) for PR #349 reformat code using spark's code style.

Also, reformat some log messages in MatcherFilter because it's really useful for the issue.
