### PR TITLE
Another (more drastic) way to fix issue #221.

### DIFF
--- a/src/main/java/spark/Access.java
+++ b/src/main/java/spark/Access.java
@@ -22,11 +22,7 @@ public final class Access {
 
     private Access() {
     }
-
-    public static String getBody(Response response) {
-        return response.body();
-    }
-
+    
     public static void changeMatch(Request request, RouteMatch match) {
         request.changeMatch(match);
     }

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -86,6 +86,10 @@ public class Request {
         // Used by wrapper
     }
 
+    Request(HttpServletRequest request) {
+        servletRequest = request;
+    }
+
     /**
      * Constructor
      *
@@ -93,7 +97,7 @@ public class Request {
      * @param request the servlet request
      */
     Request(RouteMatch match, HttpServletRequest request) {
-        this.servletRequest = request;
+        this(request);
         changeMatch(match);
     }
 

--- a/src/main/java/spark/RequestResponseFactory.java
+++ b/src/main/java/spark/RequestResponseFactory.java
@@ -19,15 +19,13 @@ package spark;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import spark.routematch.RouteMatch;
-
 public final class RequestResponseFactory {
 
     private RequestResponseFactory() {
     }
 
-    public static Request create(RouteMatch match, HttpServletRequest request) {
-        return new Request(match, request);
+    public static Request create(HttpServletRequest request) {
+        return new Request(request);
     }
 
     public static Response create(HttpServletResponse response) {

--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -38,6 +38,11 @@ public class Response {
 
     private HttpServletResponse response;
     private String body;
+    /**
+     * The payload is the body only in case it is a standard string
+     * In case of binary or stream, then the body would be <code>null</code>
+     */
+    private Object payload;
 
     protected Response() {
         // Used by wrapper
@@ -72,7 +77,7 @@ public class Response {
      * @param body the body
      */
     public void body(String body) {
-        this.body = body;
+        this.payload = this.body = body;
     }
 
     /**
@@ -84,6 +89,30 @@ public class Response {
         return this.body;
     }
 
+    /**
+     * Sets the payload
+     *
+     * @param payload the payload
+     */
+    public void payload(Object payload) {
+        if (payload instanceof String) {
+            this.body((String) payload);
+        }
+        else {
+            this.body = null;
+            this.payload = payload;
+        }
+    }
+
+    /**
+     * returns the payload
+     *
+     * @return the payload
+     */
+    public Object payload() {
+        return this.payload;
+    }
+    
     /**
      * @return the raw response object handed in by Jetty
      */

--- a/src/main/java/spark/webserver/RequestWrapper.java
+++ b/src/main/java/spark/webserver/RequestWrapper.java
@@ -29,10 +29,10 @@ import spark.routematch.RouteMatch;
 
 final class RequestWrapper extends Request {
 
-    private Request delegate;
+    final private Request delegate;
 
-    public void setDelegate(Request delegate) {
-        this.delegate = delegate;
+    public RequestWrapper(Request request) {
+        delegate = request;
     }
 
     Request getDelegate() {

--- a/src/main/java/spark/webserver/ResponseWrapper.java
+++ b/src/main/java/spark/webserver/ResponseWrapper.java
@@ -22,14 +22,14 @@ import spark.Response;
 
 class ResponseWrapper extends Response {
 
-    private Response delegate;
+    private final Response delegate;
 
     private boolean redirected = false;
 
-    public void setDelegate(Response delegate) {
-        this.delegate = delegate;
+    public ResponseWrapper(Response wrapped) {
+        delegate = wrapped;
     }
-
+    
     Response getDelegate() {
         return delegate;
     }

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -153,6 +153,30 @@ public class GenericIntegrationTest {
             response.header("after", "foobar");
         });
 
+        post("/chained_filters", (request, response) -> {
+            String body = request.body();
+            response.status(201); // created
+            return body;
+        });
+
+        before("/chained_filters", (request, response) -> {
+            response.header("X-body-before1", request.body());
+        });
+        
+        before("/chained_filters", (request, response) -> {
+            response.header("X-body-before2", request.body());
+        });
+
+        after("/chained_filters", (request, response) -> {
+            response.body(response.body() + " after1");
+            response.header("X-body-after1", response.body());
+        });
+        
+        after("/chained_filters", (request, response) -> {
+            response.body(response.body() + " after2");
+            response.header("X-body-after2", response.body());
+        });
+
         get("/throwexception", (request, response) -> {
             throw new UnsupportedOperationException();
         });
@@ -255,6 +279,17 @@ public class GenericIntegrationTest {
         Assert.assertTrue(response.headers.get("after").contains("foobar"));
     }
 
+    @Test
+    public void testChainedFilters() throws Exception {
+        UrlResponse response = testUtil.doMethod("POST", "/chained_filters", "Hello World!");
+        Assert.assertEquals(201, response.status);
+        Assert.assertEquals("Hello World!", response.headers.get("X-body-before1"));
+        Assert.assertEquals("Hello World!", response.headers.get("X-body-before2"));
+        Assert.assertEquals("Hello World! after1", response.headers.get("X-body-after1"));
+        Assert.assertEquals("Hello World! after1 after2", response.headers.get("X-body-after2"));
+    }
+
+    
     @Test
     public void testGetRoot() throws Exception {
         UrlResponse response = testUtil.doMethod("GET", "/", null);


### PR DESCRIPTION
"After filters" have only limited usage if you cannot read the payload.
There is already PR #211 trying to fix the same issue... in a different manner.

I am open for any respectful discussion on why one method would be better or worse than the other. 

My goals were to:
1. simplify the code, as well supporting the general cases:
2. the payload in not a string (and you still want to modify it in a filter)
3. you want to chain the filters (and see the changed values)

Since, I am new to Spark, I hope I don't break any logic here...

Notice that I changed the "API" to add the 'payload' to the Response (for the general case where the body would not be a simple string).

I also added a test case BTW...

Cheers

