### PR TITLE
Support for removing registered routes

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -986,6 +986,24 @@ public final class Spark {
         getInstance().stop();
     }
 
+    /**
+     * Removes the routes associated to the provided httpMethod and path
+     * @param httpMethod
+     * @param path
+     */
+    public static void removeRoute(String httpMethod, String path) {
+    	getInstance().removeRoute(httpMethod, path);
+    }
+    
+    /**
+     * Removes all the routes associated to the provided path
+     * @param httpMethod
+     * @param path
+     */
+    public static void removeRoute(String path) {
+    	getInstance().removeRoute(path);
+    }
+    
     ////////////////
     // Websockets //
 

--- a/src/main/java/spark/SparkInstance.java
+++ b/src/main/java/spark/SparkInstance.java
@@ -323,6 +323,26 @@ final class SparkInstance extends Routable {
         routeMatcher.parseValidateAddRoute(httpMethod + " '" + route.getPath() + "'", route.getAcceptType(), route);
     }
 
+    /**
+     * Removes the routes associated to the provided httpMethod and path
+     * @param httpMethod
+     * @param path
+     */
+    public void removeRoute(String httpMethod, String path) {
+    	init();
+    	routeMatcher.removeRoute(path, httpMethod);
+    }
+    
+    /**
+     * Removes all the routes associated to the provided path
+     * @param httpMethod
+     * @param path
+     */
+    public void removeRoute(String path) {
+    	init();
+    	routeMatcher.removeRoute(path);
+    }
+    
     @Override
     public void addFilter(String httpMethod, FilterImpl filter) {
         init();


### PR DESCRIPTION
These changes provide the functionality to remove already registered routes from the Spark singleton. Let's say that I have

Spark.get("/api", (request, response)->{...});

I could do

Spark.removeRoute("get", "api");
