### PR TITLE
Option to not GZIP compress content

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -37,6 +37,12 @@ public final class Spark {
     private Spark() {
     }
 
+    
+    /**
+     * 
+     */
+    public static boolean doGzip = true;
+    
     /**
      * Initializes singleton.
      */

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -39,7 +39,10 @@ public final class Spark {
 
     
     /**
-     * 
+     * Boolean to tell gziputils whether to gzip the response (if content-encoding and accept-encoding are gzip)
+     * Default is true => meaning the response will be gzipped
+     * However if set to false, the content will not be gzip compressed (i.e. if it was gzip compressed before serving)
+     * @author Anthony Bradley
      */
     public static boolean doGzip = true;
     

--- a/src/main/java/spark/utils/GzipUtils.java
+++ b/src/main/java/spark/utils/GzipUtils.java
@@ -37,7 +37,7 @@ public class GzipUtils {
     private static final String CONTENT_ENCODING = "Content-Encoding";
 
     private static final String GZIP = "gzip";
-
+    
     private static final StringMatch STRING_MATCH = new StringMatch();
 
     // Hide constructor
@@ -68,8 +68,10 @@ public class GzipUtils {
 
         if (acceptsGzip) {
             if (!requireWantsHeader || wantGzip) {
-                //responseStream = new GZIPOutputStream(responseStream, true);
+            	if(spark.Spark.doGzip==true){
+                responseStream = new GZIPOutputStream(responseStream, true);
                 addContentEncodingHeaderIfMissing(httpResponse, wantGzip);
+            	}
             }
         }
 

--- a/src/main/java/spark/utils/GzipUtils.java
+++ b/src/main/java/spark/utils/GzipUtils.java
@@ -68,7 +68,7 @@ public class GzipUtils {
 
         if (acceptsGzip) {
             if (!requireWantsHeader || wantGzip) {
-                responseStream = new GZIPOutputStream(responseStream, true);
+                //responseStream = new GZIPOutputStream(responseStream, true);
                 addContentEncodingHeaderIfMissing(httpResponse, wantGzip);
             }
         }


### PR DESCRIPTION
New functionality to allow the user to specify that data should NOT be gzip compressed by spark itself.

If content-encoding and accept-encoding are gzip -> spark by default gzip compresses the response. This is a nice feature - however may not be desired (i.e. if content is already gzip compressed). I have added an option to not gzip compress the response (using a static boolean). 
