### PR TITLE
Set content type for static file response

### DIFF
--- a/src/main/java/spark/staticfiles/StaticFiles.java
+++ b/src/main/java/spark/staticfiles/StaticFiles.java
@@ -18,6 +18,7 @@ package spark.staticfiles;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,6 +59,10 @@ public class StaticFiles {
             for (AbstractResourceHandler staticResourceHandler : staticResourceHandlers) {
                 AbstractFileResolvingResource resource = staticResourceHandler.getResource(httpRequest);
                 if (resource != null && resource.isReadable()) {
+                    String contentType = Files.probeContentType(resource.getFile().toPath());
+                    if (contentType != null) {
+                        httpResponse.setContentType(contentType);
+                    }
                     OutputStream wrappedOutputStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, false);
                     IOUtils.copy(resource.getInputStream(), wrappedOutputStream);
                     wrappedOutputStream.flush();


### PR DESCRIPTION
I keep getting this message from my browser's console
`Resource interpreted as Stylesheet but transferred with MIME type text/plain`
So, I made this fix.