### PR TITLE
Close the static file input stream when done

### DIFF
--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -17,6 +17,7 @@
 package spark.staticfiles;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Date;
@@ -92,11 +93,12 @@ public class StaticFilesConfiguration {
                         httpResponse.setHeader(MimeType.CONTENT_TYPE, MimeType.fromResource(resource));
                     }
                     customHeaders.forEach(httpResponse::setHeader); //add all user-defined headers to response
-                    OutputStream wrappedOutputStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, false);
 
-                    IOUtils.copy(resource.getInputStream(), wrappedOutputStream);
-                    wrappedOutputStream.flush();
-                    wrappedOutputStream.close();
+                    try (InputStream inputStream = resource.getInputStream();
+                         OutputStream wrappedOutputStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, false)) {
+                        IOUtils.copy(inputStream, wrappedOutputStream);
+                    }
+
                     return true;
                 }
             }


### PR DESCRIPTION
Currently, the method `spark.staticfiles.StaticFiles.consume` leaves the file input stream open. In addition to being a bad idea in general, it also means that the server process has a file lock on all the static files all the time, which makes changing them on the fly (say using `gulp watch`) impossible. This PR fixes the issue by extracting the call to `resource.getInputStream()` into its own local variable, and explicitly closing the stream.
