### PR TITLE
Adding support to set port externally with system property

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ public class HelloWorld {
 
 View at: http://localhost:4567/hello
 
+You can change default Spark port using Java system property `-Dserver.port=54321` or by
+using method `port()`.
 
 Check out and try the examples in the source code.
 You can also check out the javadoc. After getting the source from

--- a/src/main/java/spark/SparkInstance.java
+++ b/src/main/java/spark/SparkInstance.java
@@ -41,11 +41,14 @@ final class SparkInstance extends Routable {
     private static final Logger LOG = LoggerFactory.getLogger("spark.Spark");
 
     public static final int SPARK_DEFAULT_PORT = 4567;
+    public static final String SPARK_PORT_SYSTEM_PROPERTY = "server.port";
     protected static final String DEFAULT_ACCEPT_TYPE = "*/*";
 
     protected boolean initialized = false;
 
-    protected int port = SPARK_DEFAULT_PORT;
+    protected int port = Integer.parseInt(System.getProperty(
+            SPARK_PORT_SYSTEM_PROPERTY, String.valueOf(SPARK_DEFAULT_PORT)
+    ));
     protected String ipAddress = "0.0.0.0";
 
     protected SslStores sslStores;


### PR DESCRIPTION
Unfortunately Spark doesn't support setting port from system property. It's sometimes nessesery to give port for example in Heroku https://devcenter.heroku.com/articles/java-faq#what-constraints-should-i-be-aware-of-when-developing-applications-on-heroku:

> The web process must listen on one and only one port. The port must be the one specified in the $PORT variable. If your process listens on other ports, it will be shut down by Heroku.

In Spring Boot you can give port from command line like this:

`java -Dserver.port=$PORT -jar spring-app-1.0.0.jar`

In WildFly Swarm you also can give port like this:

`java -Dswarm.http.port=$PORT -jar swarm-app-1.0.0.jar`

I'm proposing to solve this by using the same property name as in Spring Boot `server.port` for easier migration between those two.

This PR will also makes posible my feature for Gasper: https://github.com/wavesoftware/java-gasper/issues/1

I tested those changes with test application.
