### PR TITLE
Type info for ExceptionHandler

### DIFF
--- a/src/main/java/spark/ExceptionHandler.java
+++ b/src/main/java/spark/ExceptionHandler.java
@@ -4,7 +4,7 @@ package spark;
  * Created by Per Wendel on 2014-05-10.
  */
 @FunctionalInterface
-public interface ExceptionHandler {
+public interface ExceptionHandler<T extends Exception> {
 
     /**
      * Invoked when an exception that is mapped to this handler occurs during routing
@@ -13,5 +13,5 @@ public interface ExceptionHandler {
      * @param request   The request object providing information about the HTTP request
      * @param response  The response object providing functionality for modifying the response
      */
-    void handle(Exception exception, Request request, Response response);
+    void handle(T exception, Request request, Response response);
 }

--- a/src/main/java/spark/ExceptionHandlerImpl.java
+++ b/src/main/java/spark/ExceptionHandlerImpl.java
@@ -16,18 +16,19 @@
  */
 package spark;
 
-public abstract class ExceptionHandlerImpl implements ExceptionHandler {
+public abstract class ExceptionHandlerImpl<T extends Exception> implements ExceptionHandler<T> {
+
     /**
      * Holds the type of exception that this filter will handle
      */
-    protected Class<? extends Exception> exceptionClass;
+    protected Class<? extends T> exceptionClass;
 
     /**
      * Initializes the filter with the provided exception type
      *
      * @param exceptionClass Type of exception
      */
-    public ExceptionHandlerImpl(Class<? extends Exception> exceptionClass) {
+    public ExceptionHandlerImpl(Class<T> exceptionClass) {
         this.exceptionClass = exceptionClass;
     }
 
@@ -36,7 +37,7 @@ public abstract class ExceptionHandlerImpl implements ExceptionHandler {
      *
      * @return Type of exception
      */
-    public Class<? extends Exception> exceptionClass() {
+    public Class<? extends T> exceptionClass() {
         return this.exceptionClass;
     }
 
@@ -45,7 +46,7 @@ public abstract class ExceptionHandlerImpl implements ExceptionHandler {
      *
      * @param exceptionClass Type of exception
      */
-    public void exceptionClass(Class<? extends Exception> exceptionClass) {
+    public void exceptionClass(Class<? extends T> exceptionClass) {
         this.exceptionClass = exceptionClass;
     }
 
@@ -56,5 +57,5 @@ public abstract class ExceptionHandlerImpl implements ExceptionHandler {
      * @param request   The request object providing information about the HTTP request
      * @param response  The response object providing functionality for modifying the response
      */
-    public abstract void handle(Exception exception, Request request, Response response);
+    public abstract void handle(T exception, Request request, Response response);
 }

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -540,11 +540,11 @@ public final class Service extends Routable {
      * @param exceptionClass the exception class
      * @param handler        The handler
      */
-    public synchronized void exception(Class<? extends Exception> exceptionClass, ExceptionHandler handler) {
+    public synchronized <T extends Exception> void exception(Class<T> exceptionClass, ExceptionHandler<? super T> handler) {
         // wrap
-        ExceptionHandlerImpl wrapper = new ExceptionHandlerImpl(exceptionClass) {
+        ExceptionHandlerImpl wrapper = new ExceptionHandlerImpl<T>(exceptionClass) {
             @Override
-            public void handle(Exception exception, Request request, Response response) {
+            public void handle(T exception, Request request, Response response) {
                 handler.handle(exception, request, response);
             }
         };

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -879,7 +879,7 @@ public class Spark {
      * @param exceptionClass the exception class
      * @param handler        The handler
      */
-    public static void exception(Class<? extends Exception> exceptionClass, ExceptionHandler handler) {
+    public static <T extends Exception> void exception(Class<T> exceptionClass, ExceptionHandler<? super T> handler) {
         getInstance().exception(exceptionClass, handler);
     }
 


### PR DESCRIPTION
Adding type information to the `ExceptionHandler`, so you do not have to cast the `Exception` to its subtype manually within the `handle` method.
