### PR TITLE
simpifies route creation

### DIFF
--- a/src/main/java/spark/Routable.java
+++ b/src/main/java/spark/Routable.java
@@ -29,8 +29,28 @@ abstract class Routable {
      *
      * @param httpMethod the HTTP method
      * @param route      the route implementation
+     * @deprecated Please, use typesafe {@link #addRoute(HttpMethod, RouteImpl)}
      */
-    protected abstract void addRoute(String httpMethod, RouteImpl route);
+    @Deprecated
+    public abstract void addRoute(String httpMethod, RouteImpl route);
+
+    /**
+     * Adds a filter
+     *
+     * @param httpMethod the HTTP method
+     * @param filter     the route implementation
+     * @deprecated Please, use typesafe {@link #addFilter(HttpMethod, FilterImpl)}
+     */
+    @Deprecated
+    public abstract void addFilter(String httpMethod, FilterImpl filter);
+
+    /**
+     * Adds a route
+     *
+     * @param httpMethod the HTTP method
+     * @param route      the route implementation
+     */
+    public abstract void addRoute(HttpMethod httpMethod, RouteImpl route);
 
     /**
      * Adds a filter
@@ -38,7 +58,8 @@ abstract class Routable {
      * @param httpMethod the HTTP method
      * @param filter     the route implementation
      */
-    protected abstract void addFilter(String httpMethod, FilterImpl filter);
+    public abstract void addFilter(HttpMethod httpMethod, FilterImpl filter);
+
 
     /////////////////////////////
     // Default implementations //
@@ -50,7 +71,7 @@ abstract class Routable {
      * @param route The route
      */
     public void get(final String path, final Route route) {
-        addRoute(HttpMethod.get.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.get, RouteImpl.create(path, route));
     }
 
     /**
@@ -60,7 +81,7 @@ abstract class Routable {
      * @param route The route
      */
     public void post(String path, Route route) {
-        addRoute(HttpMethod.post.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.post, RouteImpl.create(path, route));
     }
 
     /**
@@ -70,7 +91,7 @@ abstract class Routable {
      * @param route The route
      */
     public void put(String path, Route route) {
-        addRoute(HttpMethod.put.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.put, RouteImpl.create(path, route));
     }
 
     /**
@@ -80,7 +101,7 @@ abstract class Routable {
      * @param route The route
      */
     public void patch(String path, Route route) {
-        addRoute(HttpMethod.patch.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.patch, RouteImpl.create(path, route));
     }
 
     /**
@@ -90,7 +111,7 @@ abstract class Routable {
      * @param route The route
      */
     public void delete(String path, Route route) {
-        addRoute(HttpMethod.delete.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.delete, RouteImpl.create(path, route));
     }
 
     /**
@@ -100,7 +121,7 @@ abstract class Routable {
      * @param route The route
      */
     public void head(String path, Route route) {
-        addRoute(HttpMethod.head.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.head, RouteImpl.create(path, route));
     }
 
     /**
@@ -110,7 +131,7 @@ abstract class Routable {
      * @param route The route
      */
     public void trace(String path, Route route) {
-        addRoute(HttpMethod.trace.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.trace, RouteImpl.create(path, route));
     }
 
     /**
@@ -120,7 +141,7 @@ abstract class Routable {
      * @param route The route
      */
     public void connect(String path, Route route) {
-        addRoute(HttpMethod.connect.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.connect, RouteImpl.create(path, route));
     }
 
     /**
@@ -130,7 +151,7 @@ abstract class Routable {
      * @param route The route
      */
     public void options(String path, Route route) {
-        addRoute(HttpMethod.options.name(), RouteImpl.create(path, route));
+        addRoute(HttpMethod.options, RouteImpl.create(path, route));
     }
 
     /**
@@ -140,7 +161,7 @@ abstract class Routable {
      * @param filter The filter
      */
     public void before(String path, Filter filter) {
-        addFilter(HttpMethod.before.name(), FilterImpl.create(path, filter));
+        addFilter(HttpMethod.before, FilterImpl.create(path, filter));
     }
 
     /**
@@ -150,7 +171,7 @@ abstract class Routable {
      * @param filter The filter
      */
     public void after(String path, Filter filter) {
-        addFilter(HttpMethod.after.name(), FilterImpl.create(path, filter));
+        addFilter(HttpMethod.after, FilterImpl.create(path, filter));
     }
 
     //////////////////////////////////////////////////
@@ -165,7 +186,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void get(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.get.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.get, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -176,7 +197,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void post(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.post.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.post, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -187,7 +208,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void put(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.put.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.put, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -198,7 +219,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void patch(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.patch.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.patch, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -209,7 +230,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void delete(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.delete.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.delete, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -220,7 +241,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void head(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.head.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.head, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -231,7 +252,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void trace(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.trace.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.trace, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -242,7 +263,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void connect(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.connect.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.connect, RouteImpl.create(path, acceptType, route));
     }
 
     /**
@@ -253,7 +274,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void options(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.options.name(), RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.options, RouteImpl.create(path, acceptType, route));
     }
 
 
@@ -263,7 +284,7 @@ abstract class Routable {
      * @param filter The filter
      */
     public void before(Filter filter) {
-        addFilter(HttpMethod.before.name(), FilterImpl.create(SparkUtils.ALL_PATHS, filter));
+        addFilter(HttpMethod.before, FilterImpl.create(SparkUtils.ALL_PATHS, filter));
     }
 
     /**
@@ -272,7 +293,7 @@ abstract class Routable {
      * @param filter The filter
      */
     public void after(Filter filter) {
-        addFilter(HttpMethod.after.name(), FilterImpl.create(SparkUtils.ALL_PATHS, filter));
+        addFilter(HttpMethod.after, FilterImpl.create(SparkUtils.ALL_PATHS, filter));
     }
 
     /**
@@ -283,7 +304,7 @@ abstract class Routable {
      * @param filter     The filter
      */
     public void before(String path, String acceptType, Filter filter) {
-        addFilter(HttpMethod.before.name(), FilterImpl.create(path, acceptType, filter));
+        addFilter(HttpMethod.before, FilterImpl.create(path, acceptType, filter));
     }
 
     /**
@@ -294,7 +315,7 @@ abstract class Routable {
      * @param filter     The filter
      */
     public void after(String path, String acceptType, Filter filter) {
-        addFilter(HttpMethod.after.name(), FilterImpl.create(path, acceptType, filter));
+        addFilter(HttpMethod.after, FilterImpl.create(path, acceptType, filter));
     }
 
     //////////////////////////////////////////////////
@@ -313,7 +334,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void get(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.get.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.get, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -328,7 +349,7 @@ abstract class Routable {
                     String acceptType,
                     TemplateViewRoute route,
                     TemplateEngine engine) {
-        addRoute(HttpMethod.get.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.get, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -339,7 +360,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void post(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.post.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.post, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -354,7 +375,7 @@ abstract class Routable {
                      String acceptType,
                      TemplateViewRoute route,
                      TemplateEngine engine) {
-        addRoute(HttpMethod.post.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.post, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -365,7 +386,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void put(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.put.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.put, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -380,7 +401,7 @@ abstract class Routable {
                     String acceptType,
                     TemplateViewRoute route,
                     TemplateEngine engine) {
-        addRoute(HttpMethod.put.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.put, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -391,7 +412,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void delete(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.delete.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.delete, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -406,7 +427,7 @@ abstract class Routable {
                        String acceptType,
                        TemplateViewRoute route,
                        TemplateEngine engine) {
-        addRoute(HttpMethod.delete.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.delete, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -417,7 +438,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void patch(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.patch.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.patch, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -432,7 +453,7 @@ abstract class Routable {
                       String acceptType,
                       TemplateViewRoute route,
                       TemplateEngine engine) {
-        addRoute(HttpMethod.patch.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.patch, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -443,7 +464,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void head(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.head.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.head, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -458,7 +479,7 @@ abstract class Routable {
                      String acceptType,
                      TemplateViewRoute route,
                      TemplateEngine engine) {
-        addRoute(HttpMethod.head.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.head, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -469,7 +490,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void trace(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.trace.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.trace, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -484,7 +505,7 @@ abstract class Routable {
                       String acceptType,
                       TemplateViewRoute route,
                       TemplateEngine engine) {
-        addRoute(HttpMethod.trace.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.trace, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -495,7 +516,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void connect(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.connect.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.connect, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -510,7 +531,7 @@ abstract class Routable {
                         String acceptType,
                         TemplateViewRoute route,
                         TemplateEngine engine) {
-        addRoute(HttpMethod.connect.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.connect, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     /**
@@ -521,7 +542,7 @@ abstract class Routable {
      * @param engine the template engine
      */
     public void options(String path, TemplateViewRoute route, TemplateEngine engine) {
-        addRoute(HttpMethod.options.name(), TemplateViewRouteImpl.create(path, route, engine));
+        addRoute(HttpMethod.options, TemplateViewRouteImpl.create(path, route, engine));
     }
 
     /**
@@ -536,7 +557,7 @@ abstract class Routable {
                         String acceptType,
                         TemplateViewRoute route,
                         TemplateEngine engine) {
-        addRoute(HttpMethod.options.name(), TemplateViewRouteImpl.create(path, acceptType, route, engine));
+        addRoute(HttpMethod.options, TemplateViewRouteImpl.create(path, acceptType, route, engine));
     }
 
     //////////////////////////////////////////////////
@@ -555,7 +576,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void get(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.get.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.get, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -567,7 +588,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void get(String path, String acceptType, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.get.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.get, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -578,7 +599,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void post(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.post.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.post, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -590,7 +611,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void post(String path, String acceptType, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.post.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.post, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -601,7 +622,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void put(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.put.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.put, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -613,7 +634,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void put(String path, String acceptType, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.put.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.put, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -624,7 +645,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void delete(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.delete.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.delete, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -639,7 +660,7 @@ abstract class Routable {
                        String acceptType,
                        Route route,
                        ResponseTransformer transformer) {
-        addRoute(HttpMethod.delete.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.delete, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -650,7 +671,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void head(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.head.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.head, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -662,7 +683,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void head(String path, String acceptType, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.head.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.head, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -673,7 +694,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void connect(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.connect.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.connect, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -688,7 +709,7 @@ abstract class Routable {
                         String acceptType,
                         Route route,
                         ResponseTransformer transformer) {
-        addRoute(HttpMethod.connect.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.connect, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -699,7 +720,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void trace(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.trace.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.trace, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -714,7 +735,7 @@ abstract class Routable {
                       String acceptType,
                       Route route,
                       ResponseTransformer transformer) {
-        addRoute(HttpMethod.trace.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.trace, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -725,7 +746,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void options(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.options.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.options, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -740,7 +761,7 @@ abstract class Routable {
                         String acceptType,
                         Route route,
                         ResponseTransformer transformer) {
-        addRoute(HttpMethod.options.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.options, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
     /**
@@ -751,7 +772,7 @@ abstract class Routable {
      * @param transformer the response transformer
      */
     public void patch(String path, Route route, ResponseTransformer transformer) {
-        addRoute(HttpMethod.patch.name(), ResponseTransformerRouteImpl.create(path, route, transformer));
+        addRoute(HttpMethod.patch, ResponseTransformerRouteImpl.create(path, route, transformer));
     }
 
     /**
@@ -766,7 +787,7 @@ abstract class Routable {
                       String acceptType,
                       Route route,
                       ResponseTransformer transformer) {
-        addRoute(HttpMethod.patch.name(), ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
+        addRoute(HttpMethod.patch, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
 }

--- a/src/main/java/spark/SparkInstance.java
+++ b/src/main/java/spark/SparkInstance.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServers;
 import spark.globalstate.ServletFlag;
+import spark.route.HttpMethod;
 import spark.route.RouteMatcherFactory;
 import spark.route.SimpleRouteMatcher;
 import spark.ssl.SslStores;
@@ -278,14 +279,40 @@ final class SparkInstance extends Routable {
 
     @Override
     public void addRoute(String httpMethod, RouteImpl route) {
-        init();
-        routeMatcher.parseValidateAddRoute(httpMethod + " '" + route.getPath() + "'", route.getAcceptType(), route);
+        try {
+            addRoute(HttpMethod.valueOf(httpMethod), route);
+        } catch (IllegalArgumentException e) {
+            LOG.error("The @Route value: "
+                    + route
+                    + " has an invalid HTTP method part: "
+                    + httpMethod
+                    + ".");
+        }
     }
 
     @Override
     public void addFilter(String httpMethod, FilterImpl filter) {
+        try {
+            addFilter(HttpMethod.valueOf(httpMethod), filter);
+        } catch (IllegalArgumentException e) {
+            LOG.error("The @Filter value: "
+                    + filter
+                    + " has an invalid HTTP method part: "
+                    + httpMethod
+                    + ".");
+        }
+    }
+
+    @Override
+    public void addRoute(HttpMethod httpMethod, RouteImpl route) {
         init();
-        routeMatcher.parseValidateAddRoute(httpMethod + " '" + filter.getPath() + "'", filter.getAcceptType(), filter);
+        routeMatcher.addRoute(httpMethod, route.getPath(), route.getAcceptType(), route);
+    }
+
+    @Override
+    public void addFilter(HttpMethod httpMethod, FilterImpl filter) {
+        init();
+        routeMatcher.addRoute(httpMethod, filter.getPath(), filter.getAcceptType(), filter);
     }
 
     public synchronized void init() {

--- a/src/main/java/spark/route/SimpleRouteMatcher.java
+++ b/src/main/java/spark/route/SimpleRouteMatcher.java
@@ -51,7 +51,9 @@ public class SimpleRouteMatcher {
      * @param route      the route path
      * @param acceptType the accept type
      * @param target     the invocation target
+     * @deprecated Please, use typesafe {@link #addRoute(HttpMethod, String, String, Object)}
      */
+    @Deprecated
     public void parseValidateAddRoute(String route, String acceptType, Object target) {
         try {
             int singleQuoteIndex = route.indexOf(SINGLE_QUOTE);
@@ -64,10 +66,10 @@ public class SimpleRouteMatcher {
                 method = HttpMethod.valueOf(httpMethod);
             } catch (IllegalArgumentException e) {
                 LOG.error("The @Route value: "
-                                  + route
-                                  + " has an invalid HTTP method part: "
-                                  + httpMethod
-                                  + ".");
+                        + route
+                        + " has an invalid HTTP method part: "
+                        + httpMethod
+                        + ".");
                 return;
             }
             addRoute(method, url, acceptType, target);
@@ -126,14 +128,14 @@ public class SimpleRouteMatcher {
 
     /**
      * Removes a particular route from the collection of those that have been previously routed.
-     * Search for a previously established routes using the given path and HTTP method, removing
-     * any matches that are found.
+     * Search for a previously established routes using the given path and HTTP method, removing any
+     * matches that are found.
      *
      * @param path       the route path
      * @param httpMethod the http method
      * @return <tt>true</tt> if this a matching route has been previously routed
-     * @throws IllegalArgumentException if <tt>path</tt> is null or blank or if <tt>httpMethod</tt> is null, blank
-     *                                  or an invalid HTTP method
+     * @throws IllegalArgumentException if <tt>path</tt> is null or blank or if <tt>httpMethod</tt>
+     *                                  is null, blank or an invalid HTTP method
      * @since 2.2
      */
     public boolean removeRoute(String path, String httpMethod) {
@@ -153,7 +155,8 @@ public class SimpleRouteMatcher {
 
     /**
      * Removes a particular route from the collection of those that have been previously routed.
-     * Search for a previously established routes using the given path and removes any matches that are found.
+     * Search for a previously established routes using the given path and removes any matches that
+     * are found.
      *
      * @param path the route path
      * @return <tt>true</tt> if this a matching route has been previously routed
@@ -168,11 +171,15 @@ public class SimpleRouteMatcher {
         return removeRoute((HttpMethod) null, path);
     }
 
-    //////////////////////////////////////////////////
-    // PRIVATE METHODS
-    //////////////////////////////////////////////////
-
-    private void addRoute(HttpMethod method, String url, String acceptedType, Object target) {
+    /**
+     *
+     * @param method Http method
+     * @param url path
+     * @param acceptedType the accept type
+     * @param target     the invocation target
+     * @since 2.4
+     */
+    public void addRoute(HttpMethod method, String url, String acceptedType, Object target) {
         RouteEntry entry = new RouteEntry();
         entry.httpMethod = method;
         entry.path = url;
@@ -182,6 +189,10 @@ public class SimpleRouteMatcher {
         // Adds to end of list
         routes.add(entry);
     }
+
+    //////////////////////////////////////////////////
+    // PRIVATE METHODS
+    //////////////////////////////////////////////////
 
     //can be cached? I don't think so.
     private Map<String, RouteEntry> getAcceptedMimeTypes(List<RouteEntry> routes) {


### PR DESCRIPTION
1\? for #479 

adds public APIs:
SimpleRouteMatcher#addRoute
Routable#addRoute(spark.route.HttpMethod, spark.RouteImpl)
Routable#addFilter(spark.route.HttpMethod, spark.FilterImpl)
deprecates unneeded\unsafe:
SimpleRouteMatcher#parseValidateAddRoute
Routable#addRoute(java.lang.String, spark.RouteImpl)
Routable#addFilter(java.lang.String, spark.FilterImpl)
