### PR TITLE
Clear ExceptionMapper mappings on stop, analog to clear routes

### DIFF
--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -105,4 +105,12 @@ public class ExceptionMapper {
     public ExceptionHandlerImpl getHandler(Exception exception) {
         return this.getHandler(exception.getClass());
     }
+
+    /**
+     * Clear the exception mappings.
+     */
+    public void clear() {
+        this.exceptionMap.clear();
+    }
+
 }

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -90,6 +90,7 @@ public final class Service extends Routable {
     public final StaticFiles staticFiles;
 
     private final StaticFilesConfiguration staticFilesConfiguration;
+    private final ExceptionMapper exceptionMapper = ExceptionMapper.getInstance();
 
     // default exception handler during initialization phase
     private Consumer<Exception> initExceptionHandler = (e) -> {
@@ -422,6 +423,7 @@ public final class Service extends Routable {
             }
             
             routes.clear();
+            exceptionMapper.clear();
             staticFilesConfiguration.clear();
             initialized = false;
         }).start();
@@ -549,7 +551,7 @@ public final class Service extends Routable {
             }
         };
 
-        ExceptionMapper.getInstance().map(exceptionClass, wrapper);
+        exceptionMapper.map(exceptionClass, wrapper);
     }
 
     //////////////////////////////////////////////////


### PR DESCRIPTION
I have spend quite a lot of time debugging this "static state leak" when I experienced this between integration tests. I think it makes sense to treat mapped exception handlers analog to added routes once the server stops.
