### PR TITLE
Add method to set response content length

### DIFF
--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -77,7 +77,7 @@ public class Response {
         response.setContentType(contentType);
     }
 
-/**
+    /**
      * Returns the content type
      *
      * @return the content type

--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -92,6 +92,10 @@ public class Response {
         }
     }
 
+    /**
+     * Measures <code>body</code> content
+     * length.
+     */
     protected void calculateContentLength() {
         String charsetValue = response.getCharacterEncoding() == null ?
                 "ISO-8859-1" // recommended charset according to http://www.ietf.org/rfc/rfc2047.txt

--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -88,17 +88,21 @@ public class Response {
         this.body = body;
 
         if (!contentLengthManuallySet) {
-            String charsetValue = response.getCharacterEncoding() == null ?
-                    "ISO-8859-1" // recommended charset according to http://www.ietf.org/rfc/rfc2047.txt
-                    : response.getCharacterEncoding();
+            calculateContentLength();
+        }
+    }
 
-            Charset charset = null; //Charset.forName(charsetValue);
+    protected void calculateContentLength() {
+        String charsetValue = response.getCharacterEncoding() == null ?
+                "ISO-8859-1" // recommended charset according to http://www.ietf.org/rfc/rfc2047.txt
+                : response.getCharacterEncoding();
 
-            if (charset != null) {
-                response.setContentLength(this.body.getBytes(charset).length);
-            } else if (LOG.isDebugEnabled()) {
-                LOG.debug("unable to retrieve charset for name '{}'", charsetValue);
-            }
+        Charset charset = Charset.forName(charsetValue);
+
+        if (charset != null) {
+            response.setContentLength(this.body.getBytes(charset).length);
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("unable to retrieve charset for name '{}'", charsetValue);
         }
     }
 

--- a/src/test/java/spark/ResponseTest.java
+++ b/src/test/java/spark/ResponseTest.java
@@ -60,7 +60,7 @@ public class ResponseTest {
         verify(httpServletResponse).getContentType();
     }
 
-	@Test
+    @Test
     public void testLength(){
         final int finalLength = "Hello World".getBytes().length;
 

--- a/src/test/java/spark/ResponseTest.java
+++ b/src/test/java/spark/ResponseTest.java
@@ -49,6 +49,14 @@ public class ResponseTest {
     }
 
     @Test
+    public void testLength(){
+        final int finalLength = "Hello World".getBytes().length;
+
+        response.length(finalLength);
+        verify(httpServletResponse).setContentLength(finalLength);
+    }
+
+    @Test
     public void testSetBody(){
         final String finalBody = "Hello world!";
 


### PR DESCRIPTION
This method is a convenient way to set response content length.

It is equivalent to do `Response#header("Content-Length", String.valueOf(length))`, but it uses `javax.servlet.ServletResponse` API and automatically set the length on `spark.Response#body(String)` if not already set.
