### PR TITLE
Fix for #251

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -4,7 +4,7 @@
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -53,6 +53,8 @@ public class Request {
     private HttpServletRequest servletRequest;
 
     private Session session = null;
+    private boolean validSession = false;
+
 
     /* Lazy loaded stuff */
     private String body = null;
@@ -385,8 +387,9 @@ public class Request {
      * @return the session associated with this request
      */
     public Session session() {
-        if (session == null) {
-            session = new Session(servletRequest.getSession());
+        if (session == null || !validSession) {
+            validSession(true);
+            session = new Session(servletRequest.getSession(), this);
         }
         return session;
     }
@@ -401,10 +404,13 @@ public class Request {
      * <code>create</code> is <code>false</code> and the request has no valid session
      */
     public Session session(boolean create) {
-        if (session == null) {
+        if (session == null || !validSession) {
             HttpSession httpSession = servletRequest.getSession(create);
             if (httpSession != null) {
-                session = new Session(httpSession);
+                validSession(true);
+                session = new Session(httpSession, this);
+            } else {
+                session = null;
             }
         }
         return session;
@@ -500,6 +506,15 @@ public class Request {
             }
         }
         return Collections.unmodifiableList(splat);
+    }
+
+    /**
+     * Set the session validity
+     *
+     * @param validSession the session validity
+     */
+    void validSession(boolean validSession) {
+        this.validSession = validSession;
     }
 
 }

--- a/src/main/java/spark/Session.java
+++ b/src/main/java/spark/Session.java
@@ -6,6 +6,8 @@ import java.util.TreeSet;
 
 import javax.servlet.http.HttpSession;
 
+import spark.utils.Assert;
+
 /**
  * Provides session information.
  */
@@ -22,12 +24,8 @@ public class Session {
      * @throws IllegalArgumentException If the session or the request is null.
      */
     Session(HttpSession session, Request request) {
-        if (session == null) {
-            throw new IllegalArgumentException("session cannot be null");
-        }
-        if (request == null) {
-            throw new IllegalArgumentException("request cannot be null");
-        }
+        Assert.notNull(session, "session cannot be null");
+        Assert.notNull(request, "request cannot be null");
         this.session = session;
         this.request = request;
     }

--- a/src/main/java/spark/Session.java
+++ b/src/main/java/spark/Session.java
@@ -11,19 +11,25 @@ import javax.servlet.http.HttpSession;
  */
 public class Session {
 
-    private HttpSession session;
+    private final Request request;
+    private final HttpSession session;
 
     /**
      * Creates a session with the <code>HttpSession</code>.
      *
      * @param session
-     * @throws IllegalArgumentException If the session is null.
+     * @param request
+     * @throws IllegalArgumentException If the session or the request is null.
      */
-    Session(HttpSession session) {
+    Session(HttpSession session, Request request) {
         if (session == null) {
             throw new IllegalArgumentException("session cannot be null");
         }
+        if (request == null) {
+            throw new IllegalArgumentException("request cannot be null");
+        }
         this.session = session;
+        this.request = request;
     }
 
     /**
@@ -112,6 +118,7 @@ public class Session {
      * Invalidates this session then unbinds any objects bound to it.
      */
     public void invalidate() {
+        request.validSession(false);
         session.invalidate();
     }
 

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -149,6 +149,16 @@ public class GenericIntegrationTest {
             return "Body was: " + body;
         });
 
+        get("/session_reset", (request, response) -> {
+            String key = "session_reset";
+            Session session = request.session();
+            session.attribute(key, "11111");
+            session.invalidate();
+            session = request.session();
+            session.attribute(key, "22222");
+            return session.attribute(key);
+        });
+
         after("/hi", (request, response) -> {
             response.header("after", "foobar");
         });
@@ -367,6 +377,13 @@ public class GenericIntegrationTest {
         LOGGER.info(response.body);
         Assert.assertEquals(200, response.status);
         Assert.assertTrue(response.body.contains("Fo shizzy"));
+    }
+
+    @Test
+    public void testSessionReset() throws Exception {
+        UrlResponse response = testUtil.doMethod("GET", "/session_reset", null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("22222", response.body);
     }
 
     @Test

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -11,6 +11,8 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RequestTest {
@@ -100,6 +102,51 @@ public class RequestTest {
         assertEquals("A Session should not have been created because create parameter was set to false",
                 null, request.session(false));
 
+    }
+
+    @Test
+    public void testSessionNpParams_afterSessionInvalidate() {
+        when(servletRequest.getSession()).thenReturn(httpSession);
+
+        Session session = request.session();
+        session.invalidate();
+        request.session();
+
+        verify(servletRequest, times(2)).getSession();
+    }
+
+    @Test
+    public void testSession_whenCreateIsTrue_afterSessionInvalidate() {
+        when(servletRequest.getSession(true)).thenReturn(httpSession);
+
+        Session session = request.session(true);
+        session.invalidate();
+        request.session(true);
+
+        verify(servletRequest, times(2)).getSession(true);
+    }
+
+    @Test
+    public void testSession_whenCreateIsFalse_afterSessionInvalidate() {
+        when(servletRequest.getSession()).thenReturn(httpSession);
+        when(servletRequest.getSession(false)).thenReturn(null);
+
+        Session session = request.session();
+        session.invalidate();
+        request.session(false);
+
+        verify(servletRequest, times(1)).getSession(false);
+    }
+
+    @Test
+    public void testSession_2times() {
+        when(servletRequest.getSession(true)).thenReturn(httpSession);
+
+        Session session = request.session(true);
+        session = request.session(true);
+
+        assertNotNull(session);
+        verify(servletRequest, times(1)).getSession(true);
     }
 
     @Test

--- a/src/test/java/spark/SessionTest.java
+++ b/src/test/java/spark/SessionTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.*;
 
 public class SessionTest {
 
+    Request request;
     HttpSession httpSession;
     Session session;
 
@@ -23,7 +24,8 @@ public class SessionTest {
     public void setup() {
 
         httpSession = mock(HttpSession.class);
-        session = new Session(httpSession);
+        request = mock(Request.class);
+        session = new Session(httpSession, request);
     }
 
     @Test
@@ -31,12 +33,26 @@ public class SessionTest {
 
         try {
 
-            new Session(null);
+            new Session(null, request);
             fail("Session instantiation with a null HttpSession should throw an IllegalArgumentException");
 
-        } catch(IllegalArgumentException ex) {
+        } catch (IllegalArgumentException ex) {
 
             assertEquals("session cannot be null", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testSession_whenRequestIsNull_thenThrowException() {
+
+        try {
+
+            new Session(httpSession, null);
+            fail("Session instantiation with a null Request should throw an IllegalArgumentException");
+
+        } catch (IllegalArgumentException ex) {
+
+            assertEquals("request cannot be null", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
After invalidating a session, returns new session.
```
Session session = request.session();
session.invalidate();
session = request.session(); // get new sesssion
session.attribute("XXX", "YYY"); // don't throw exception
```

Add the `validSession` to conditions to get the new session in Request.

