### PR TITLE
Fix for #535. Static files in jar

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -47,7 +47,7 @@ public class MatcherFilter implements Filter {
     private static final String ACCEPT_TYPE_REQUEST_MIME_HEADER = "Accept";
     private static final String HTTP_METHOD_OVERRIDE_HEADER = "X-HTTP-Method-Override";
 
-    private final StaticFilesConfiguration staticFilesConfiguration;
+    private final StaticFilesConfiguration staticFiles;
 
     private spark.route.Routes routeMatcher;
     private SerializerChain serializerChain;
@@ -64,12 +64,12 @@ public class MatcherFilter implements Filter {
      * @param hasOtherHandlers  If true, do nothing if request is not consumed by Spark in order to let others handlers process the request.
      */
     public MatcherFilter(spark.route.Routes routeMatcher,
-                         StaticFilesConfiguration staticFilesConfiguration,
+                         StaticFilesConfiguration staticFiles,
                          boolean externalContainer,
                          boolean hasOtherHandlers) {
 
         this.routeMatcher = routeMatcher;
-        this.staticFilesConfiguration = staticFilesConfiguration;
+        this.staticFiles = staticFiles;
         this.externalContainer = externalContainer;
         this.hasOtherHandlers = hasOtherHandlers;
         this.serializerChain = new SerializerChain();
@@ -88,7 +88,7 @@ public class MatcherFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
 
         // handle static resources
-        boolean consumedByStaticFile = staticFilesConfiguration.consume(httpRequest, httpResponse);
+        boolean consumedByStaticFile = staticFiles.consume(httpRequest, httpResponse);
 
         if (consumedByStaticFile) {
             return;

--- a/src/main/java/spark/http/matching/Routes.java
+++ b/src/main/java/spark/http/matching/Routes.java
@@ -66,7 +66,11 @@ final class Routes {
                 content = result;
 
                 if (content instanceof String) {
-                    context.responseWrapper().body((String) content);
+                    String contentStr = (String) content;
+
+                    if (!contentStr.equals("")) {
+                        context.responseWrapper().body(contentStr);
+                    }
                 }
             }
         }

--- a/src/main/java/spark/resource/AbstractResourceHandler.java
+++ b/src/main/java/spark/resource/AbstractResourceHandler.java
@@ -77,7 +77,7 @@ public abstract class AbstractResourceHandler {
      * @param segment2 URI path segment (should be encoded)
      * @return Legally combined path segments.
      */
-    protected static String addPaths(String segment1, String segment2) {
+    public static String addPaths(String segment1, String segment2) {
         if (segment1 == null || segment1.length() == 0) {
             if (segment1 != null && segment2 == null) {
                 return segment1;

--- a/src/main/java/spark/resource/JarResourceHandler.java
+++ b/src/main/java/spark/resource/JarResourceHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 - Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.resource;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import spark.utils.Assert;
+
+import static spark.resource.AbstractResourceHandler.addPaths;
+
+/**
+ * Locates resources in jar file
+ */
+public class JarResourceHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JarResourceHandler.class);
+
+    private final String baseResource;
+    private String welcomeFile;
+
+    /**
+     * Constructor
+     *
+     * @param baseResource the base resource path
+     * @param welcomeFile  the welcomeFile
+     */
+    public JarResourceHandler(String baseResource, String welcomeFile) {
+        Assert.notNull(baseResource);
+
+        this.baseResource = baseResource;
+        this.welcomeFile = welcomeFile;
+    }
+
+    public InputStream getResource(HttpServletRequest request) throws MalformedURLException {
+
+        String servletPath;
+        String pathInfo;
+
+        boolean included = request.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI) != null;
+
+        if (included) {
+            servletPath = (String) request.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
+            pathInfo = (String) request.getAttribute(RequestDispatcher.INCLUDE_PATH_INFO);
+
+            if (servletPath == null && pathInfo == null) {
+                servletPath = request.getServletPath();
+                pathInfo = request.getPathInfo();
+            }
+        } else {
+            servletPath = request.getServletPath();
+            pathInfo = request.getPathInfo();
+        }
+
+        String pathInContext = addPaths(servletPath, pathInfo);
+        return getResourceStream(pathInContext);
+    }
+
+    private InputStream getResourceStream(String path) throws MalformedURLException {
+        if (path == null || !path.startsWith("/")) {
+            throw new MalformedURLException(path);
+        }
+
+        InputStream resourceStream = null;
+
+        try {
+            path = UriPath.canonical(path);
+            path = addPaths(baseResource, path);
+
+            if (isDirectory(path)) {
+                if (welcomeFileConfigured()) {
+                    path = addPaths(path, welcomeFile);
+                    resourceStream = loadStream(path);
+                }
+            } else {
+                resourceStream = loadStream(path);
+            }
+
+        } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(e.getClass().getSimpleName() + " when trying to get resource. " + e.getMessage());
+            }
+        }
+
+        return resourceStream;
+    }
+
+    private InputStream loadStream(String path) {
+        return JarResourceHandler.class.getResourceAsStream(path);
+    }
+
+    private boolean welcomeFileConfigured() {
+        return welcomeFile != null;
+    }
+
+    private boolean isDirectory(String path) {
+        return path.endsWith("/");
+    }
+
+}


### PR DESCRIPTION
The ClassPathResourceHandler doesn't work when trying to access files in a jar. I've written a JarResourceHandler that does this. Should solve #535 