### PR TITLE
Postpone param/splat decoding until after matching.

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -16,6 +16,8 @@
  */
 package spark;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -470,11 +472,19 @@ public class Request {
         for (int i = 0; (i < request.size()) && (i < matched.size()); i++) {
             String matchedPart = matched.get(i);
             if (SparkUtils.isParam(matchedPart)) {
-                LOG.debug("matchedPart: "
-                                  + matchedPart
-                                  + " = "
-                                  + request.get(i));
-                params.put(matchedPart.toLowerCase(), request.get(i));
+                try
+                {
+                    String decodedReq = URLDecoder.decode(request.get(i), "UTF-8");
+                    LOG.debug("matchedPart: "
+                            + matchedPart
+                            + " = "
+                            + decodedReq);
+                    params.put(matchedPart.toLowerCase(), decodedReq);
+
+                } catch (UnsupportedEncodingException e)
+                {
+
+                }
             }
         }
         return Collections.unmodifiableMap(params);
@@ -502,7 +512,13 @@ public class Request {
                         splatParam.append(request.get(j));
                     }
                 }
-                splat.add(splatParam.toString());
+                try
+                {
+                    String decodedSplat = URLDecoder.decode(splatParam.toString(), "UTF-8");
+                    splat.add(decodedSplat);
+                } catch (UnsupportedEncodingException e)
+                {
+                }
             }
         }
         return Collections.unmodifiableList(splat);

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -97,7 +97,7 @@ public class MatcherFilter implements Filter {
         String method = getHttpMethodFrom(httpRequest);
 
         String httpMethodStr = method.toLowerCase();
-        String uri = httpRequest.getPathInfo();
+        String uri = httpRequest.getRequestURI();
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
         Body body = Body.create();

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
@@ -305,6 +306,26 @@ public class GenericIntegrationTest {
         UrlResponse response = testUtil.doMethod("GET", "/param/" + encoded, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: " + polyglot, response.body);
+    }
+
+    @Test
+    public void testParamWithEncodedSlash() throws Exception {
+        String polyglot = "te/st";
+        String encoded = URLEncoder.encode(polyglot, "UTF-8");
+        UrlResponse response = testUtil.doMethod("GET", "/param/" + encoded, null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("echo: " + polyglot, response.body);
+    }
+
+    @Test
+    public void testSplatWithEncodedSlash() throws Exception {
+        String param = "fo/shizzle";
+        String encodedParam = URLEncoder.encode(param, "UTF-8");
+        String splat = "mah/FRIEND";
+        String encodedSplat = URLEncoder.encode(splat, "UTF-8");
+        UrlResponse response = testUtil.doMethod("GET", "/paramandwild/" + encodedParam + "/stuff/" + encodedSplat, null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("paramandwild: " + param + splat, response.body);
     }
 
     @Test


### PR DESCRIPTION
Adresses #528 #343 #267 #266  
Instead of taking the already decoded URI from jetty `httpRequest.getPathInfo()` we go back to the way it was done before [b621367](https://github.com/perwendel/spark/commit/b6213676146c3d78fa0b38870fa3b4ff1dedd7c0), using `httpRequest.getRequestURI()` and decode the parameters just before they are added to the params map instead. 

This solves the problem of matching routes using encoded slashes.