### PR TITLE
Added method signatures for multiple filters; Allow custom 404 and 500 pages

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -164,6 +164,18 @@ public class Spark {
     }
 
     /**
+     * Maps an array of filters to be executed before any matching routes
+     * @param path    the path
+     * @param filters the filters
+     */
+
+    public static void before(String path, Filter... filters) {
+        for(Filter filter : filters) {
+            getInstance().before(path, filter);
+        }
+    }
+
+    /**
      * Maps a filter to be executed after any matching routes
      *
      * @param path   the path
@@ -171,6 +183,19 @@ public class Spark {
      */
     public static void after(String path, Filter filter) {
         getInstance().after(path, filter);
+    }
+
+    /**
+     * Maps an array of filters to be executed after any matching routes
+     *
+     * @param path   the path
+     * @param filters The filters
+     */
+
+    public static void after(String path, Filter... filters) {
+        for(Filter filter : filters) {
+            getInstance().after(path, filter);
+        }
     }
 
     //////////////////////////////////////////////////
@@ -287,12 +312,34 @@ public class Spark {
     }
 
     /**
+     * Maps an array of filters to be executed before any matching routes
+     *
+     * @param filters The filters
+     */
+    public static void before(Filter... filters) {
+        for(Filter filter : filters) {
+            getInstance().before(filter);
+        }
+    }
+
+    /**
      * Maps a filter to be executed after any matching routes
      *
      * @param filter The filter
      */
     public static void after(Filter filter) {
         getInstance().after(filter);
+    }
+
+    /**
+     * Maps an array of filters to be executed after any matching routes
+     *
+     * @param filters The filters
+     */
+    public static void after(Filter... filters) {
+        for(Filter filter : filters) {
+            getInstance().after(filter);
+        }
     }
 
     /**
@@ -307,6 +354,19 @@ public class Spark {
     }
 
     /**
+     * Maps an array of filters to be executed before any matching routes
+     *
+     * @param path       the path
+     * @param acceptType the accept type
+     * @param filters    The filters
+     */
+    public static void before(String path, String acceptType, Filter... filters) {
+        for(Filter filter : filters) {
+            getInstance().before(path, acceptType, filter);
+        }
+    }
+
+    /**
      * Maps a filter to be executed after any matching routes
      *
      * @param path       the path
@@ -315,6 +375,19 @@ public class Spark {
      */
     public static void after(String path, String acceptType, Filter filter) {
         getInstance().after(path, acceptType, filter);
+    }
+
+    /**
+     * Maps an array of filters to be executed after any matching routes
+     *
+     * @param path       the path
+     * @param acceptType the accept type
+     * @param filters    The filters
+     */
+    public static void after(String path, String acceptType, Filter... filters) {
+        for(Filter filter : filters) {
+            getInstance().after(path, acceptType, filter);
+        }
     }
 
     //////////////////////////////////////////////////

--- a/src/main/java/spark/http/matching/GeneralError.java
+++ b/src/main/java/spark/http/matching/GeneralError.java
@@ -16,10 +16,12 @@
  */
 package spark.http.matching;
 
-import javax.servlet.http.HttpServletResponse;
-
 import spark.ExceptionHandlerImpl;
 import spark.ExceptionMapper;
+import spark.utils.ResourceUtils;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.InputStream;
 
 /**
  * Modifies the HTTP response and body based on the provided exception and request/response wrappers.
@@ -48,7 +50,11 @@ final class GeneralError {
             }
         } else {
             httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            body.set(INTERNAL_ERROR);
+            e.printStackTrace();
+            InputStream inputStream = GeneralError.class.getClassLoader().getResourceAsStream("500.html");
+            String contents = ResourceUtils.readResourceContents(inputStream);
+            if(contents != null) body.set(contents);
+            else body.set(INTERNAL_ERROR);
         }
     }
 

--- a/src/main/java/spark/utils/ResourceUtils.java
+++ b/src/main/java/spark/utils/ResourceUtils.java
@@ -18,11 +18,9 @@ package spark.utils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
+import java.io.InputStream;
+import java.net.*;
+import java.util.Scanner;
 
 /**
  * Utility methods for resolving resource locations to files in the
@@ -348,6 +346,22 @@ public abstract class ResourceUtils {
      */
     public static void useCachesIfNecessary(URLConnection con) {
         con.setUseCaches(con.getClass().getSimpleName().startsWith("JNLP"));
+    }
+
+    /**
+     * Reads the contents of a file in the resources directory.
+     * @param resourceInputStream A {@code java.io.InputStream} to the file you want to read.
+     * @return A {@code java.util.String} of the contents of the file
+     */
+    public static String readResourceContents(InputStream resourceInputStream) {
+        if(resourceInputStream != null) {
+            String contents = "";
+            Scanner scanner = new Scanner(resourceInputStream);
+            while (scanner.hasNext()) contents += scanner.nextLine();
+            scanner.close();
+            return contents;
+        } else return  null;
+
     }
 
 }

--- a/src/test/java/spark/MultipleFiltersTest.java
+++ b/src/test/java/spark/MultipleFiltersTest.java
@@ -1,0 +1,86 @@
+package spark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+
+import static spark.Spark.*;
+
+/**
+ * Basic test to ensure that multiple before and after filters can be mapped to a route.
+ */
+public class MultipleFiltersTest {
+    private static SparkTestUtil http;
+    private static class User {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    private static class LoadUser implements Filter {
+        @Override
+        public void handle(Request request, Response response) throws Exception {
+            User u = new User();
+            u.setName("Kevin");
+            request.attribute("user", u);
+        }
+    }
+    private static class SetCounter implements Filter {
+        @Override
+        public void handle(Request request, Response response) throws Exception {
+            request.attribute("counter", 0);
+        }
+    }
+
+    private static class IncrementCounter implements Filter {
+        @Override
+        public void handle(Request request, Response response) throws Exception {
+            int counter = request.attribute("counter");
+            counter++;
+            request.attribute("counter", counter);
+        }
+    }
+
+    @BeforeClass
+    public static void setup() {
+        http = new SparkTestUtil(4567);
+
+        before("/user", new SetCounter(), new IncrementCounter(), new LoadUser());
+
+        after("/user", new IncrementCounter(), (req, res) -> {
+            int counter = req.attribute("counter");
+            Assert.assertEquals(counter, 2);
+        });
+
+        get("/user", (request, response) -> {
+            Assert.assertEquals((int)request.attribute("counter"), 1);
+            return ((User) request.attribute("user")).getName();
+        });
+
+        Spark.awaitInitialization();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        Spark.stop();
+    }
+
+    @Test
+    public void testMultipleFilters() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/user");
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("Kevin", response.body);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/spark/http/matching/MatcherFilterTest.java
+++ b/src/test/java/spark/http/matching/MatcherFilterTest.java
@@ -1,0 +1,57 @@
+package spark.http.matching;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.Spark;
+import spark.util.SparkTestUtil;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by Kevin on 5/14/2016.
+ */
+public class MatcherFilterTest {
+    private static SparkTestUtil http;
+    private static class Problem {
+        public String create() throws Exception {
+            throw new Exception();
+        }
+    }
+    @BeforeClass
+    public static void setup() {
+        http = new SparkTestUtil(4567);
+        Spark.get("/", ((request, response) -> "Home"));
+        Spark.get("/error", ((request, response) -> new Problem().create()));
+        Spark.awaitInitialization();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        Spark.stop();
+    }
+
+    @Test
+    public void testCustom404() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/kevin");
+            assertEquals("Response status is 404", 404, response.status);
+            assertTrue("Body has contents of custom HTML", response.body.contains(":-("));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testCustom500() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/error");
+            assertEquals("Response status is 404", 500, response.status);
+            System.out.println(response.body);
+            assertTrue("Body has contents of custom HTML", response.body.contains("Oops"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/resources/404.html
+++ b/src/test/resources/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>404</title>
+</head>
+<body>
+<h1>Couldn't find that page :-(</h1>
+</body>
+</html>

--- a/src/test/resources/500.html
+++ b/src/test/resources/500.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Internal Server Error</title>
+</head>
+<body>
+    <h1>Oops, that's an error :-(</h1>
+</body>
+</html>


### PR DESCRIPTION
- Adds method signatures to allow multiple filters to be applied to before/after actions.
- Allows you to specify custom 404 and 500 error pages by placing a 404.html and a 500.html file in the resources folder. Falls back to default behaviour if files are not present.
