### PR TITLE
added missing delegate implementation in ResponseWrapper

### DIFF
--- a/src/main/java/spark/http/matching/ResponseWrapper.java
+++ b/src/main/java/spark/http/matching/ResponseWrapper.java
@@ -127,6 +127,11 @@ class ResponseWrapper extends Response {
     }
 
     @Override
+    public void cookie(String path, String name, String value, int maxAge, boolean secured, boolean httpOnly) {
+        delegate.cookie(path, name, value, maxAge, secured, httpOnly);
+    }
+
+    @Override
     public void removeCookie(String name) {
         delegate.removeCookie(name);
     }


### PR DESCRIPTION
this missing delegate causes a null pointer exception when using "public void cookie(String path, String name, String value, int maxAge, boolean secured, boolean httpOnly) "