### PR TITLE
add missing delegate methods to ResponseWrapper

### DIFF
--- a/src/main/java/spark/http/matching/ResponseWrapper.java
+++ b/src/main/java/spark/http/matching/ResponseWrapper.java
@@ -48,6 +48,11 @@ class ResponseWrapper extends Response {
     }
 
     @Override
+    public int status() {
+        return delegate.status();
+    }
+
+    @Override
     public void body(String body) {
         delegate.body(body);
     }
@@ -104,6 +109,11 @@ class ResponseWrapper extends Response {
     @Override
     public void type(String contentType) {
         delegate.type(contentType);
+    }
+
+    @Override
+    public String type() {
+        return delegate.type();
     }
 
     @Override

--- a/src/test/java/spark/ResponseWrapperDelegationTest.java
+++ b/src/test/java/spark/ResponseWrapperDelegationTest.java
@@ -1,0 +1,71 @@
+package spark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+import spark.util.SparkTestUtil.UrlResponse;
+
+import java.io.IOException;
+
+import static spark.Spark.*;
+
+public class ResponseWrapperDelegationTest {
+
+    static SparkTestUtil testUtil;
+
+    @AfterClass
+    public static void tearDown() {
+        Spark.stop();
+    }
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        testUtil = new SparkTestUtil(4567);
+
+        get("/204", (q, a) -> {
+            a.status(204);
+            return "";
+        });
+
+        after("/204", (q, a) -> {
+            if (a.status() == 204) {
+                a.status(200);
+                a.body("ok");
+            }
+        });
+
+        get("/json", (q, a) -> {
+            a.type("application/json");
+            return "{\"status\": \"ok\"}";
+        });
+
+        after("/json", (q, a) -> {
+            if ("application/json".equalsIgnoreCase(a.type())) {
+                a.type("text/plain");
+            }
+        });
+
+        exception(Exception.class, (exception, q, a) -> {
+            exception.printStackTrace();
+        });
+
+        Spark.awaitInitialization();
+    }
+
+    @Test
+    public void filters_can_detect_response_status() throws Exception {
+        UrlResponse response = testUtil.get("/204");
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("ok", response.body);
+    }
+
+    @Test
+    public void filters_can_detect_content_type() throws Exception {
+        UrlResponse response = testUtil.get("/json");
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("{\"status\": \"ok\"}", response.body);
+        Assert.assertEquals("text/plain", response.headers.get("Content-Type"));
+    }
+}


### PR DESCRIPTION
As I commented in PR [572](https://github.com/perwendel/spark/pull/572), there are other methods missing from the delegation, too.

I noticed the omission when writing an after-filter which tried to access response.status() and got an NPE. 

This PR adds the methods (and a test demonstrating the problem). 