### PR TITLE
Issue-446 Allow a user to retrieve the allocated port the server is r…

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -132,6 +132,21 @@ public final class Service extends Routable {
     }
 
     /**
+     * Retrieves the port that Spark is listening on.
+     *
+     * @throws IllegalStateException when the server is not started
+     *
+     * @return The port Spark server is listening on.
+     */
+    public synchronized int getPort() {
+        if (initialized) {
+            return port;
+        } else {
+            throw new IllegalStateException("This must be done after route mapping has begun");
+        }
+    }
+
+    /**
      * Set the connection to be secure, using the specified keystore and
      * truststore. This has to be called before any route mapping is done. You
      * have to supply a keystore file, truststore file is optional (keystore
@@ -346,7 +361,7 @@ public final class Service extends Routable {
 
                     server.configureWebSockets(webSocketHandlers, webSocketIdleTimeoutMillis);
 
-                    server.ignite(
+                    port = server.ignite(
                             ipAddress,
                             port,
                             sslStores,

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -936,6 +936,17 @@ public class Spark {
     }
 
     /**
+     * Retrieves the port that Spark is listening on.
+     *
+     * @throws IllegalStateException when the server is not started
+     *
+     * @return The port Spark server is listening on.
+     */
+    public static int getPort() {
+        return getInstance().getPort();
+    }
+
+    /**
      * Set the connection to be secure, using the specified keystore and
      * truststore. This has to be called before any route mapping is done. You
      * have to supply a keystore file, truststore file is optional (keystore

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -38,8 +38,10 @@ public interface EmbeddedServer {
      * @param maxThreads              - max nbr of threads.
      * @param minThreads              - min nbr of threads.
      * @param threadIdleTimeoutMillis - idle timeout (ms).
+     *
+     * @return The port number the server was launched on.
      */
-    void ignite(String host,
+    int ignite(String host,
                 int port,
                 SslStores sslStores,
                 CountDownLatch latch,

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -71,7 +71,7 @@ public class EmbeddedJettyServer implements EmbeddedServer {
      * {@inheritDoc}
      */
     @Override
-    public void ignite(String host,
+    public int ignite(String host,
                        int port,
                        SslStores sslStores,
                        CountDownLatch latch,
@@ -132,6 +132,8 @@ public class EmbeddedJettyServer implements EmbeddedServer {
             logger.error("ignite failed", e);
             System.exit(100); // NOSONAR
         }
+
+        return port;
     }
 
     /**

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -118,6 +118,36 @@ public class ServiceTest {
     }
 
     @Test
+    public void testGetPort_whenInitializedFalse_thenThrowIllegalStateException() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("This must be done after route mapping has begun");
+
+        Whitebox.setInternalState(service, "initialized", false);
+        service.getPort();
+    }
+
+    @Test
+    public void testGetPort_whenInitializedTrue() {
+        int expectedPort = 8080;
+        Whitebox.setInternalState(service, "initialized", true);
+        Whitebox.setInternalState(service, "port", expectedPort);
+
+        int actualPort = service.getPort();
+
+        assertEquals("Port retrieved should be the port setted", expectedPort, actualPort);
+    }
+
+    @Test
+    public void testGetPort_whenInitializedTrue_Default() {
+        int expectedPort = Service.SPARK_DEFAULT_PORT;
+        Whitebox.setInternalState(service, "initialized", true);
+
+        int actualPort = service.getPort();
+
+        assertEquals("Port retrieved should be the port setted", expectedPort, actualPort);
+    }
+
+    @Test
     public void testThreadPool_whenOnlyMaxThreads() {
         service.threadPool(100);
         int maxThreads = Whitebox.getInternalState(service, "maxThreads");


### PR DESCRIPTION
…unning on

When writing tests, I don't want my test to fail if the port I want to run Spark on is used by an other program.
Thus, I need to use a random port for Spark.
However, I have no mean to retrieve it from my code, making the server impossible to test.

Related to https://github.com/perwendel/spark/issues/446 and https://github.com/perwendel/spark/issues/400

The basic idea behind this PR is that the Embedded server should return the port it was effectively launched on. Hence we can retrieve the allocated port without changing the logic.