### PR TITLE
Add web fonts mime types to MimeType inner map

### DIFF
--- a/src/main/java/spark/staticfiles/MimeType.java
+++ b/src/main/java/spark/staticfiles/MimeType.java
@@ -39,6 +39,7 @@ public class MimeType {
         put("doc", "application/msword");
         put("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
         put("dotx", "application/vnd.openxmlformats-officedocument.wordprocessingml.template");
+        put("eot", "application/vnd.ms-fontobject");
         put("es", "application/ecmascript");
         put("exe", "application/octet-stream");
         put("gif", "image/gif");
@@ -52,6 +53,7 @@ public class MimeType {
         put("mp3", "audio/mpeg");
         put("mpeg", "video/mpeg");
         put("ogg", "audio/vorbis,application/ogg");
+        put("otf", "application/font-otf");
         put("pdf", "application/pdf");
         put("pl", "application/x-perl");
         put("png", "image/png");
@@ -74,8 +76,10 @@ public class MimeType {
         put("tgz", "application/x-tar");
         put("tiff", "image/tiff");
         put("tsv", "text/tab-separated-values");
+        put("ttf", "application/font-ttf");
         put("txt", "text/plain");
         put("wav", "audio/wav,audio/x-wav");
+        put("woff", "application/font-woff");
         put("xlam", "application/vnd.ms-excel.addin.macroEnabled.12");
         put("xls", "application/vnd.ms-excel");
         put("xlsb", "application/vnd.ms-excel.sheet.binary.macroEnabled.12");

--- a/src/main/java/spark/staticfiles/MimeType.java
+++ b/src/main/java/spark/staticfiles/MimeType.java
@@ -80,6 +80,7 @@ public class MimeType {
         put("txt", "text/plain");
         put("wav", "audio/wav,audio/x-wav");
         put("woff", "application/font-woff");
+        put("woff2", "application/font-woff2");
         put("xlam", "application/vnd.ms-excel.addin.macroEnabled.12");
         put("xls", "application/vnd.ms-excel");
         put("xlsb", "application/vnd.ms-excel.sheet.binary.macroEnabled.12");


### PR DESCRIPTION
Hi,

As Spark will be guessing some mime types, would be nice to have web fonts mime types too.

Best regards.