### PR TITLE
Logging error when not caught by an exception handler

### DIFF
--- a/src/main/java/spark/ExceptionHandlerImpl.java
+++ b/src/main/java/spark/ExceptionHandlerImpl.java
@@ -16,7 +16,7 @@
  */
 package spark;
 
-public abstract class ExceptionHandlerImpl {
+public abstract class ExceptionHandlerImpl implements ExceptionHandler {
     /**
      * Holds the type of exception that this filter will handle
      */

--- a/src/main/java/spark/Redirect.java
+++ b/src/main/java/spark/Redirect.java
@@ -61,6 +61,9 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type GET, POST, PUT, DELETE on 'fromPath' to 'toPath'
+     *
+     * @param fromPath from path
+     * @param toPath   to path
      */
     public void any(String fromPath, String toPath) {
         any(fromPath, toPath, null);
@@ -68,6 +71,9 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type GET on 'fromPath' to 'toPath'
+     *
+     * @param fromPath from path
+     * @param toPath   to path
      */
     public void get(String fromPath, String toPath) {
         get(fromPath, toPath, null);
@@ -75,6 +81,9 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type POST on 'fromPath' to 'toPath'
+     *
+     * @param fromPath from path
+     * @param toPath   to path
      */
     public void post(String fromPath, String toPath) {
         post(fromPath, toPath, null);
@@ -82,6 +91,9 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type PUT on 'fromPath' to 'toPath'
+     *
+     * @param fromPath from path
+     * @param toPath   to path
      */
     public void put(String fromPath, String toPath) {
         put(fromPath, toPath, null);
@@ -89,6 +101,9 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type DELETE on 'fromPath' to 'toPath'
+     *
+     * @param fromPath from path
+     * @param toPath   to path
      */
     public void delete(String fromPath, String toPath) {
         delete(fromPath, toPath, null);
@@ -97,6 +112,10 @@ public final class Redirect {
     /**
      * Redirects any HTTP request of type GET, POST, PUT, DELETE on 'fromPath' to 'toPath' with the provided redirect
      * 'status' code.
+     *
+     * @param fromPath from path
+     * @param toPath   to path
+     * @param status   status code
      */
     public void any(String fromPath, String toPath, Status status) {
         get(fromPath, toPath, status);
@@ -107,6 +126,10 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type GET on 'fromPath' to 'toPath' with the provided redirect 'status' code.
+     *
+     * @param fromPath from path
+     * @param toPath   to path
+     * @param status   status code
      */
     public void get(String fromPath, String toPath, Status status) {
         http.get(fromPath, redirectRoute(toPath, status));
@@ -114,6 +137,10 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type POST on 'fromPath' to 'toPath' with the provided redirect 'status' code.
+     *
+     * @param fromPath from path
+     * @param toPath   to path
+     * @param status   status code
      */
     public void post(String fromPath, String toPath, Status status) {
         http.post(fromPath, redirectRoute(toPath, status));
@@ -121,6 +148,10 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type PUT on 'fromPath' to 'toPath' with the provided redirect 'status' code.
+     *
+     * @param fromPath from path
+     * @param toPath   to path
+     * @param status   status code
      */
     public void put(String fromPath, String toPath, Status status) {
         http.put(fromPath, redirectRoute(toPath, status));
@@ -128,6 +159,10 @@ public final class Redirect {
 
     /**
      * Redirects any HTTP request of type DELETE on 'fromPath' to 'toPath' with the provided redirect 'status' code.
+     *
+     * @param fromPath from path
+     * @param toPath   to path
+     * @param status   status code
      */
     public void delete(String fromPath, String toPath, Status status) {
         http.delete(fromPath, redirectRoute(toPath, status));

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -85,6 +85,8 @@ public final class Service extends Routable {
     /**
      * Creates a new Service (a Spark instance). This should be used instead of the static API if the user wants
      * multiple services in one process.
+     *
+     * @return the newly created object
      */
     public static Service ignite() {
         return new Service();
@@ -107,6 +109,7 @@ public final class Service extends Routable {
      * done.
      *
      * @param ipAddress The ipAddress
+     * @return the object with IP address set
      */
     public synchronized Service ipAddress(String ipAddress) {
         if (initialized) {
@@ -123,6 +126,7 @@ public final class Service extends Routable {
      * If provided port = 0 then the an arbitrary available port will be used.
      *
      * @param port The port number
+     * @return the object with port set
      */
     public synchronized Service port(int port) {
         if (initialized) {
@@ -146,6 +150,7 @@ public final class Service extends Routable {
      * @param truststoreFile     the truststore file location as string, leave null to reuse
      *                           keystore
      * @param truststorePassword the trust store password
+     * @return the object with connection set to be secure
      */
     public synchronized Service secure(String keystoreFile,
                                        String keystorePassword,
@@ -168,6 +173,7 @@ public final class Service extends Routable {
      * Configures the embedded web server's thread pool.
      *
      * @param maxThreads max nbr of threads.
+     * @return the object with the embedded web server's thread pool configured
      */
     public synchronized Service threadPool(int maxThreads) {
         return threadPool(maxThreads, -1, -1);
@@ -179,6 +185,7 @@ public final class Service extends Routable {
      * @param maxThreads        max nbr of threads.
      * @param minThreads        min nbr of threads.
      * @param idleTimeoutMillis thread idle timeout (ms).
+     * @return the object with the embedded web server's thread pool configured
      */
     public synchronized Service threadPool(int maxThreads, int minThreads, int idleTimeoutMillis) {
         if (initialized) {
@@ -197,6 +204,7 @@ public final class Service extends Routable {
      * must be called before all other methods.
      *
      * @param folder the folder in classpath.
+     * @return the object with folder set
      */
     public synchronized Service staticFileLocation(String folder) {
         if (initialized && !isRunningFromServlet()) {
@@ -219,6 +227,7 @@ public final class Service extends Routable {
      * must be called before all other methods.</b>
      *
      * @param externalFolder the external folder serving static files.
+     * @return the object with external folder set
      */
     public synchronized Service externalStaticFileLocation(String externalFolder) {
         if (initialized && !isRunningFromServlet()) {
@@ -267,6 +276,7 @@ public final class Service extends Routable {
      * Sets the max idle timeout in milliseconds for WebSocket connections.
      *
      * @param timeoutMillis The max idle timeout in milliseconds.
+     * @return the object with max idle timeout set for WebSocket connections
      */
     public synchronized Service webSocketIdleTimeoutMillis(int timeoutMillis) {
         if (initialized) {
@@ -399,6 +409,8 @@ public final class Service extends Routable {
      * Immediately stops a request within a filter or route
      * NOTE: When using this don't catch exceptions of type HaltException, or if catched, re-throw otherwise
      * halt will not work
+     *
+     * @return HaltException object
      */
     public HaltException halt() {
         throw new HaltException();
@@ -410,6 +422,7 @@ public final class Service extends Routable {
      * halt will not work
      *
      * @param status the status code
+     * @return HaltException object with status code set
      */
     public HaltException halt(int status) {
         throw new HaltException(status);
@@ -421,6 +434,7 @@ public final class Service extends Routable {
      * halt will not work
      *
      * @param body The body content
+     * @return HaltException object with body set
      */
     public HaltException halt(String body) {
         throw new HaltException(body);
@@ -433,6 +447,7 @@ public final class Service extends Routable {
      *
      * @param status The status code
      * @param body   The body content
+     * @return HaltException object with status and body set
      */
     public HaltException halt(int status, String body) {
         throw new HaltException(status, body);
@@ -476,6 +491,9 @@ public final class Service extends Routable {
         /**
          * Puts custom header for static resources. If the headers previously contained a mapping for
          * the key, the old value is replaced by the specified value.
+         *
+         * @param key the key
+         * @param value the value
          */
         public void header(String key, String value) {
             staticFilesConfiguration.putCustomHeader(key, value);

--- a/src/main/java/spark/http/matching/GeneralError.java
+++ b/src/main/java/spark/http/matching/GeneralError.java
@@ -16,16 +16,18 @@
  */
 package spark.http.matching;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.ExceptionHandlerImpl;
 import spark.ExceptionMapper;
+
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Modifies the HTTP response and body based on the provided exception and request/response wrappers.
  */
 final class GeneralError {
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeneralError.class);
     private static final String INTERNAL_ERROR = "<html><body><h2>500 Internal Error</h2></body></html>";
 
     /**
@@ -47,6 +49,7 @@ final class GeneralError {
                 body.set(bodyAfterFilter);
             }
         } else {
+            LOGGER.warn("Exception: ", e);
             httpResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             body.set(INTERNAL_ERROR);
         }

--- a/src/main/java/spark/http/matching/ResponseWrapper.java
+++ b/src/main/java/spark/http/matching/ResponseWrapper.java
@@ -48,6 +48,11 @@ class ResponseWrapper extends Response {
     }
 
     @Override
+    public int status() {
+        return delegate.status();
+    }
+
+    @Override
     public void body(String body) {
         delegate.body(body);
     }
@@ -104,6 +109,11 @@ class ResponseWrapper extends Response {
     @Override
     public void type(String contentType) {
         delegate.type(contentType);
+    }
+
+    @Override
+    public String type() {
+        return delegate.type();
     }
 
     @Override

--- a/src/test/java/spark/ResponseWrapperDelegationTest.java
+++ b/src/test/java/spark/ResponseWrapperDelegationTest.java
@@ -1,0 +1,71 @@
+package spark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+import spark.util.SparkTestUtil.UrlResponse;
+
+import java.io.IOException;
+
+import static spark.Spark.*;
+
+public class ResponseWrapperDelegationTest {
+
+    static SparkTestUtil testUtil;
+
+    @AfterClass
+    public static void tearDown() {
+        Spark.stop();
+    }
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        testUtil = new SparkTestUtil(4567);
+
+        get("/204", (q, a) -> {
+            a.status(204);
+            return "";
+        });
+
+        after("/204", (q, a) -> {
+            if (a.status() == 204) {
+                a.status(200);
+                a.body("ok");
+            }
+        });
+
+        get("/json", (q, a) -> {
+            a.type("application/json");
+            return "{\"status\": \"ok\"}";
+        });
+
+        after("/json", (q, a) -> {
+            if ("application/json".equalsIgnoreCase(a.type())) {
+                a.type("text/plain");
+            }
+        });
+
+        exception(Exception.class, (exception, q, a) -> {
+            exception.printStackTrace();
+        });
+
+        Spark.awaitInitialization();
+    }
+
+    @Test
+    public void filters_can_detect_response_status() throws Exception {
+        UrlResponse response = testUtil.get("/204");
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("ok", response.body);
+    }
+
+    @Test
+    public void filters_can_detect_content_type() throws Exception {
+        UrlResponse response = testUtil.get("/json");
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("{\"status\": \"ok\"}", response.body);
+        Assert.assertEquals("text/plain", response.headers.get("Content-Type"));
+    }
+}


### PR DESCRIPTION
Logging error when not caught by an exception handler.

I had a problem when I was working with spark and did not have an ExceptionHandler mapped. The exception that was thrown was not logged. This led to a very lengthy debugging session which could have avoided by logging the exception.
