### PR TITLE
Fix javadoc error and warnings in several files

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -42,7 +42,7 @@ import static spark.globalstate.ServletFlag.isRunningFromServlet;
  * the semantic makes sense. For example 'http' is a good variable name since when adding routes it would be:
  * Service http = ignite();
  * ...
- * http.get("/hello", (q, a) -> "Hello World");
+ * http.get("/hello", (q, a) {@literal ->} "Hello World");
  */
 public final class Service extends Routable {
     private static final Logger LOG = LoggerFactory.getLogger("spark.Spark");

--- a/src/main/java/spark/TemplateViewRoute.java
+++ b/src/main/java/spark/TemplateViewRoute.java
@@ -34,7 +34,7 @@ public interface TemplateViewRoute {
      * @param request  The request object providing information about the HTTP request
      * @param response The response object providing functionality for modifying the response
      * @return The content to be set in the response
-     * @throws java.lang.Exception
+     * @throws java.lang.Exception when handle fails
      */
     ModelAndView handle(Request request, Response response) throws Exception;
 

--- a/src/main/java/spark/embeddedserver/EmbeddedServerFactory.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServerFactory.java
@@ -26,6 +26,11 @@ public interface EmbeddedServerFactory {
 
     /**
      * Creates an embedded server instance.
+     *
+     * @param routeMatcher The route matcher
+     * @param staticFilesConfiguration The static files configuration object
+     * @param hasMultipleHandler true if other handlers exist
+     * @return the created instance
      */
     public EmbeddedServer create(Routes routeMatcher, StaticFilesConfiguration staticFilesConfiguration, boolean hasMultipleHandler);
 }

--- a/src/main/java/spark/embeddedserver/EmbeddedServers.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServers.java
@@ -45,6 +45,12 @@ public class EmbeddedServers {
 
     /**
      * Creates an embedded server of type corresponding to the provided identifier.
+     *
+     * @param identifier               the identifier
+     * @param routeMatcher             the route matcher
+     * @param staticFilesConfiguration the static files configuration object
+     * @param multipleHandlers         true if other handlers exist
+     * @return the created EmbeddedServer object
      */
     public static EmbeddedServer create(Object identifier,
                                         Routes routeMatcher,
@@ -62,6 +68,9 @@ public class EmbeddedServers {
 
     /**
      * Adds an Embedded server factory for the provided identifier.
+     *
+     * @param identifier the identifier
+     * @param factory    the factory
      */
     public static void add(Object identifier, EmbeddedServerFactory factory) {
         factories.put(identifier, factory);

--- a/src/main/java/spark/embeddedserver/NotSupportedException.java
+++ b/src/main/java/spark/embeddedserver/NotSupportedException.java
@@ -25,6 +25,9 @@ public class NotSupportedException extends RuntimeException {
 
     /**
      * Raises a NotSupportedException for the provided class name and feature name.
+     *
+     * @param clazz   the class name
+     * @param feature the feature name
      */
     public static void raise(String clazz, String feature) {
         throw new NotSupportedException(clazz, feature);

--- a/src/main/java/spark/http/matching/Halt.java
+++ b/src/main/java/spark/http/matching/Halt.java
@@ -27,6 +27,10 @@ public class Halt {
 
     /**
      * Modifies the HTTP response and body based on the provided HaltException.
+     *
+     * @param httpResponse The HTTP servlet response
+     * @param body         The body content
+     * @param halt         The halt exception object
      */
     public static void modify(HttpServletResponse httpResponse, Body body, HaltException halt) {
 

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -59,6 +59,7 @@ public class MatcherFilter implements Filter {
      * Constructor
      *
      * @param routeMatcher      The route matcher
+     * @param staticFiles       The static files configuration object
      * @param externalContainer Tells the filter that Spark is run in an external web container.
      *                          If true, chain.doFilter will be invoked if request is not consumed by Spark.
      * @param hasOtherHandlers  If true, do nothing if request is not consumed by Spark in order to let others handlers process the request.

--- a/src/main/java/spark/route/HttpMethod.java
+++ b/src/main/java/spark/route/HttpMethod.java
@@ -35,6 +35,9 @@ public enum HttpMethod {
     /**
      * Gets the HttpMethod corresponding to the provided string. If no corresponding method can be found
      * {@link spark.route.HttpMethod#unsupported} will be returned.
+     *
+     * @param methodStr The string containing HTTP method name
+     * @return          The HttpMethod corresponding to the provided string
      */
     public static HttpMethod get(String methodStr) {
         HttpMethod method = methods.get(methodStr);

--- a/src/main/java/spark/route/SimpleRouteMatcher.java
+++ b/src/main/java/spark/route/SimpleRouteMatcher.java
@@ -28,6 +28,9 @@ import spark.routematch.RouteMatch;
 public class SimpleRouteMatcher extends Routes {
 
     /**
+     * @param route      the route
+     * @param acceptType the accept type
+     * @param target     the target
      * @deprecated
      */
     public void parseValidateAddRoute(String route, String acceptType, Object target) {
@@ -35,6 +38,10 @@ public class SimpleRouteMatcher extends Routes {
     }
 
     /**
+     * @param httpMethod the HttpMethod
+     * @param path       the path
+     * @param acceptType the accept type
+     * @return the RouteMatch object
      * @deprecated
      */
     public RouteMatch findTargetForRequestedRoute(HttpMethod httpMethod, String path, String acceptType) {
@@ -42,6 +49,10 @@ public class SimpleRouteMatcher extends Routes {
     }
 
     /**
+     * @param httpMethod the HttpMethod
+     * @param path       the path
+     * @param acceptType the accept type
+     * @return list of RouteMatch objects
      * @deprecated
      */
     public List<RouteMatch> findTargetsForRequestedRoute(HttpMethod httpMethod, String path, String acceptType) {
@@ -56,6 +67,9 @@ public class SimpleRouteMatcher extends Routes {
     }
 
     /**
+     * @param path       the path
+     * @param httpMethod the http method name
+     * @return true if route removed, false otherwise
      * @deprecated
      */
     public boolean removeRoute(String path, String httpMethod) {
@@ -63,6 +77,8 @@ public class SimpleRouteMatcher extends Routes {
     }
 
     /**
+     * @param path   the path
+     * @return true if route removed, false otherwise
      * @deprecated
      */
     public boolean removeRoute(String path) {

--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -60,7 +60,12 @@ public class StaticFilesConfiguration {
     private Map<String, String> customHeaders = new HashMap<>();
 
     /**
+     * Attempt consuming using either static resource handlers or jar resource handlers
+     *
+     * @param httpRequest  The HTTP servlet request.
+     * @param httpResponse The HTTP servlet response.
      * @return true if consumed, false otherwise.
+     * @throws IOException in case of IO error.
      */
     public boolean consume(HttpServletRequest httpRequest,
                            HttpServletResponse httpResponse) throws IOException {


### PR DESCRIPTION
Javadoc modifications were made to following files, a summary of modifications:

Service.java
    Fixed javadoc error "bad use of >". Enclosed -> in @literal

TemplateViewRoute.java
    @throws added

EmbeddedServerFactory.java
    @param added
    @return added

EmbeddedServers.java
    @param added
    @return added

NotSupportedException.java
    @param added

Halt.java
    @param added

MatcherFilter.java
    @param added

HttpMethod
    @param added
    @return added

StaticFilesConfiguration.java
    Method description added
    @param added
    @throws added

SimpleRouteMatcher.java (this is a deprecated class. I added javadoc anyway to suppress maven warnings)
    @param added
    @return added
