### PR TITLE
Fixes #563

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -315,14 +315,19 @@ public final class Service extends Routable {
      * Stops the Spark server and clears all routes
      */
     public synchronized void stop() {
-        if (server != null) {
-            routes.clear();
-            server.extinguish();
-            latch = new CountDownLatch(1);
-        }
+        new Thread() {
+            @Override
+            public void run() {
+                if (server != null) {
+                    routes.clear();
+                    server.extinguish();
+                    latch = new CountDownLatch(1);
+                }
 
-        staticFilesConfiguration.clear();
-        initialized = false;
+                staticFilesConfiguration.clear();
+                initialized = false;
+            }
+        }.start();
     }
 
     @Override


### PR DESCRIPTION
The stop function cannot be ran in the same thread as the route handling thread so it has to be wrapped into another thread.
This ensures that no matter where you stop the server from it always shuts down gracefully.