### PR TITLE
Bugfix: content-type of static files

### DIFF
--- a/src/main/java/spark/resource/ExternalResource.java
+++ b/src/main/java/spark/resource/ExternalResource.java
@@ -86,4 +86,14 @@ public class ExternalResource extends AbstractFileResolvingResource {
     public String getPath() {
         return file.getPath();
     }
+    
+    @Override
+    public String getFilename() {
+    	
+    	if(file != null){
+    		return file.getName();
+    	}
+    	
+    	return super.getFilename();
+    }
 }


### PR DESCRIPTION
Without this commit static files are always served with content-type "application/octet-stream" as spark.staticfiles.StaticFilesConfiguration.consumeWithFileResourceHandlers calls spark.staticfiles.MimeType.fromResource to infer the content-type from the filename.
The latter calls resource.getFilename which falls back to base class implementation (which returns null) in case of ExternalResource.