### PR TITLE
Add HTTP method to route-not-mapped info

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -149,7 +149,7 @@ public class MatcherFilter implements Filter {
         }
 
         if (body.notSet() && !externalContainer) {
-			LOG.info("The requested route [" + method + " " + uri + "] has not been mapped in Spark");
+            LOG.info("The requested route [" + method + " " + uri + "] has not been mapped in Spark");
             httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
             body.set(String.format(NOT_FOUND));
         }

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -149,7 +149,7 @@ public class MatcherFilter implements Filter {
         }
 
         if (body.notSet() && !externalContainer) {
-            LOG.info("The requested route [" + uri + "] has not been mapped in Spark");
+			LOG.info("The requested route [" + method + " " + uri + "] has not been mapped in Spark");
             httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
             body.set(String.format(NOT_FOUND));
         }


### PR DESCRIPTION
The info that is logged when an incoming request uses an unmapped route only printed the path, but not the method.
That made the statement ambiguous, since you could e.g. have mapped the route for POST, but not for GET.

BEFORE:
INFO spark.http.matching.MatcherFilter - The requested route [POST /myapi/v1/blogpost/] has not been mapped in Spark

AFTER:
INFO spark.http.matching.MatcherFilter - The requested route [/myapi/v1/blogpost/] has not been mapped in Spark