### PR TITLE
Adding a method to configure max size of HTTP headers.

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -936,6 +936,18 @@ public class Spark {
     }
 
     /**
+     * Sets the maximum size of both accepted request headers and response headers.
+     * This has to be called before any route mapping is done.
+     * If not called, maximum size of headers is set to 8192 bytes, as defined in
+     * {@see Service.SPARK_DEFAULT_MAX_HEADERS_SIZE}.
+     *
+     * @param maxHeaderSize Maximum headers size in bytes
+     */
+    public static void maxHeadersSize(final int maxHeaderSize) {
+        getInstance().maxHeadersSize(maxHeaderSize);
+    }
+
+    /**
      * Set the connection to be secure, using the specified keystore and
      * truststore. This has to be called before any route mapping is done. You
      * have to supply a keystore file, truststore file is optional (keystore

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -16,11 +16,11 @@
  */
 package spark.embeddedserver;
 
+import spark.ssl.SslStores;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-
-import spark.ssl.SslStores;
 
 /**
  * Represents an embedded server that can be used in Spark. (this is currently Jetty by default).
@@ -38,6 +38,7 @@ public interface EmbeddedServer {
      * @param maxThreads              - max nbr of threads.
      * @param minThreads              - min nbr of threads.
      * @param threadIdleTimeoutMillis - idle timeout (ms).
+     * @param maxHeadersSize          - maximum size of http request/response headers
      */
     void ignite(String host,
                 int port,
@@ -45,7 +46,8 @@ public interface EmbeddedServer {
                 CountDownLatch latch,
                 int maxThreads,
                 int minThreads,
-                int threadIdleTimeoutMillis);
+                int threadIdleTimeoutMillis,
+                int maxHeadersSize);
 
     /**
      * Configures the web sockets for the embedded server.

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -16,14 +16,6 @@
  */
 package spark.embeddedserver.jetty;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -32,10 +24,17 @@ import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import spark.ssl.SslStores;
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.jetty.websocket.WebSocketServletContextHandlerFactory;
+import spark.ssl.SslStores;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Spark server implementation
@@ -77,7 +76,8 @@ public class EmbeddedJettyServer implements EmbeddedServer {
                        CountDownLatch latch,
                        int maxThreads,
                        int minThreads,
-                       int threadIdleTimeoutMillis) {
+                       int threadIdleTimeoutMillis,
+                       int maxHeadersSize) {
 
         if (port == 0) {
             try (ServerSocket s = new ServerSocket(0)) {
@@ -93,9 +93,9 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         ServerConnector connector;
 
         if (sslStores == null) {
-            connector = SocketConnectorFactory.createSocketConnector(server, host, port);
+            connector = SocketConnectorFactory.createSocketConnector(server, host, port, maxHeadersSize);
         } else {
-            connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores);
+            connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores, maxHeadersSize);
         }
 
         server = connector.getServer();

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -1,14 +1,13 @@
 package spark;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.powermock.reflect.Whitebox;
-
 import spark.ssl.SslStores;
+
+import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -25,7 +24,7 @@ public class ServiceTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void test() {
+    public void before_each_test() {
         service = ignite();
     }
 
@@ -192,5 +191,22 @@ public class ServiceTest {
 
         Whitebox.setInternalState(service, "initialized", true);
         service.webSocket("/", Object.class);
+    }
+
+    @Test
+    public void should_set_maxHeadersSize_when_service_is_not_initialized() throws Exception {
+        service.maxHeadersSize(1234);
+
+        final int maxHeadersSize = Whitebox.getInternalState(service, "maxHeadersSize");
+        assertEquals("MaxHeadersSize should be set to the value provided.", 1234, maxHeadersSize);
+    }
+
+    @Test
+    public void should_throw_exception_if_setting_maxHeadersSize_when_service_is_initialized() throws Exception {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("This must be done before route mapping has begun");
+
+        Whitebox.setInternalState(service, "initialized", true);
+        service.maxHeadersSize(1234);
     }
 }


### PR DESCRIPTION
I've stumbled upon an issue that I've had to deal with client that is using huge headers (more than 16k) and Jetty's defaults were not good enough. This PR provides a Spark.maxHeadersSize(size) method that sets max headers size for both requests and responses.
This required a little change in SocketConnectorFactory class to pass HttpConnectionFactory explicitly (it has been used anyway, but previously was not created in Spark code). 
