### PR TITLE
Implement getFilename for ExternalResource

### DIFF
--- a/src/main/java/spark/resource/ExternalResource.java
+++ b/src/main/java/spark/resource/ExternalResource.java
@@ -86,4 +86,18 @@ public class ExternalResource extends AbstractFileResolvingResource {
     public String getPath() {
         return file.getPath();
     }
+
+    /**
+     * This implementation returns the name of the file that this external
+     * resource refers to.
+     *
+     * @see spark.utils.StringUtils#getFilename(String)
+     *
+     * @return the file name.
+     */
+    @Override
+    public String getFilename() {
+        return StringUtils.getFilename(getPath());
+    }
+
 }

--- a/src/test/java/spark/StaticFilesTest.java
+++ b/src/test/java/spark/StaticFilesTest.java
@@ -100,6 +100,7 @@ public class StaticFilesTest {
         Assert.assertEquals("image/svg+xml",            doGet("/img/sparklogo.svg").headers.get("Content-Type"));
         Assert.assertEquals("application/octet-stream", doGet("/img/sparklogoPng").headers.get("Content-Type"));
         Assert.assertEquals("application/octet-stream", doGet("/img/sparklogoSvg").headers.get("Content-Type"));
+        Assert.assertEquals("text/html",                doGet("/externalFile.html").headers.get("Content-Type"));
     }
 
     @Test


### PR DESCRIPTION
The [mime type detection](https://github.com/perwendel/spark/blob/12774f1f20e2871c4dd19293d08dcf5afdd484db/src/main/java/spark/staticfiles/MimeType.java#L98) is based on the filename. This commit adds an implementation of `getFilename` for `ExternalResource` so the mime type is also set on external static files.