### PR TITLE
log which accept header is not mapped

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -149,7 +149,8 @@ public class MatcherFilter implements Filter {
         }
 
         if (body.notSet() && !externalContainer) {
-            LOG.info("The requested route [" + uri + "] has not been mapped in Spark");
+            LOG.info("The requested route [{}] has not been mapped in Spark for {}: [{}]",
+                uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
             httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
             body.set(String.format(NOT_FOUND));
         }


### PR DESCRIPTION
If the route is rejected because of the Accept header, it's useful to know which one was used.

Also, changing to using SLF4J's parameter `{}` syntax.
