### PR TITLE
Expose the context path (if deployed inside a Servlet container)

### DIFF
--- a/src/main/java/spark/globalstate/ServletFlag.java
+++ b/src/main/java/spark/globalstate/ServletFlag.java
@@ -24,12 +24,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ServletFlag {
 
     private static AtomicBoolean isRunningFromServlet = new AtomicBoolean(false);
+    private static String contextPath = null;
 
     /**
      * Tells the system that Spark was run from an "external" web application server.
+     * @param contextPath The context path under which the Spark application is deployed.
      */
-    public static void runFromServlet() {
+    public static void runFromServlet(String contextPath) {
         isRunningFromServlet.set(true);
+        ServletFlag.contextPath = contextPath;
     }
 
     /**
@@ -39,4 +42,10 @@ public class ServletFlag {
         return isRunningFromServlet.get();
     }
 
+    /**
+     * @return the context path under which the Spark application is deployed.
+     */
+    public static String getContextPath() {
+        return contextPath;
+    }
 }

--- a/src/main/java/spark/servlet/SparkFilter.java
+++ b/src/main/java/spark/servlet/SparkFilter.java
@@ -61,7 +61,8 @@ public class SparkFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        ServletFlag.runFromServlet();
+        String contextPath = filterConfig.getServletContext().getContextPath();
+        ServletFlag.runFromServlet(contextPath);
 
         applications = getApplications(filterConfig);
 

--- a/src/test/java/spark/globalstate/ServletFlagTest.java
+++ b/src/test/java/spark/globalstate/ServletFlagTest.java
@@ -30,7 +30,7 @@ public class ServletFlagTest {
     @Test
     public void testRunFromServlet_whenExecuted() throws Exception {
 
-        ServletFlag.runFromServlet();
+        ServletFlag.runFromServlet("/test");
         AtomicBoolean isRunningFromServlet = Whitebox.getInternalState(ServletFlag.class, "isRunningFromServlet");
 
         assertTrue("Should be true because it flag has been set after runFromServlet", isRunningFromServlet.get());
@@ -46,7 +46,7 @@ public class ServletFlagTest {
     @Test
     public void testIsRunningFromServlet_whenRunningFromServlet() throws Exception {
 
-        ServletFlag.runFromServlet();
+        ServletFlag.runFromServlet("/test");
         assertTrue("Should be true because call to runFromServlet has been made", ServletFlag.isRunningFromServlet());
     }
 }


### PR DESCRIPTION
When a Spark application is deployed inside a Servlet container, it is oftentimes not deployed under the context root, but under a certain context instead.
This PR exposes that context path to the application. It can be used to generate e.g. links to other pages inside a Spark application, to static resources inside the application, etc.

I'm not completely sure this is the best way to do it. Feel free to suggest improvements if you feel it could be done in a better way.