### PR TITLE
Fix serving static resources in WildFly

### DIFF
--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -178,7 +178,8 @@ public class StaticFilesConfiguration {
     }
 
     private boolean configureJarCase(String folder, ClassPathResource resource) throws IOException {
-        if (resource.getURL().getProtocol().equals("jar")) {
+        String protocol = resource.getURL().getProtocol();
+        if ("jar".equals(protocol) || "vfs".equals(protocol)) {
 
             InputStream stream = StaticFilesConfiguration.class.getResourceAsStream(folder);
 


### PR DESCRIPTION
While building a Spark app that will be deployed in WildFly 10, I noticed that static resources didn't work. It turns out that WildFly doesn't give a `jar://` URL when loading a resource from the classpath, but instead the URL starts with `vfs://`. Loading the resource using `getResourceAsStream` later on works as expected, so the only thing that needed changing was a simple check on the resource URL protocol.
