### PR TITLE
add hasKey method

### DIFF
--- a/src/main/java/spark/QueryParamsMap.java
+++ b/src/main/java/spark/QueryParamsMap.java
@@ -207,6 +207,13 @@ public class QueryParamsMap {
     }
 
     /**
+     * @return true if the map contains the given key
+     */
+    public boolean hasKey(String key) {
+    	return this.queryMap.containsKey( key );
+    }
+
+    /**
      * @return has values
      */
     public boolean hasValue() {

--- a/src/test/java/spark/QueryParamsMapTest.java
+++ b/src/test/java/spark/QueryParamsMapTest.java
@@ -38,7 +38,11 @@ public class QueryParamsMapTest {
         assertFalse(queryMap.getQueryMap().get("user").getQueryMap().get("info").getQueryMap().isEmpty());
         assertEquals("federico",queryMap.getQueryMap().get("user").getQueryMap().get("info").getQueryMap().get("first_name").getValues()[0]);
         assertEquals("dayan",queryMap.getQueryMap().get("user").getQueryMap().get("info").getQueryMap().get("last_name").getValues()[0]);
-        
+
+        assertTrue(queryMap.hasKey("user"));
+        assertFalse(queryMap.hasKey("frame"));
+        assertFalse(queryMap.hasKey(null));
+
         assertTrue(queryMap.hasKeys());
         assertFalse(queryMap.hasValue());
         assertTrue(queryMap.getQueryMap().get("user").getQueryMap().get("info").getQueryMap().get("last_name").hasValue());


### PR DESCRIPTION
I would like to add a hasKey (or containsKey if you like) method to QueryParamsMap. The use case is for a Boolean queryParam entry that has a default value. An example would be:

url/?describe
or
url/?describe=true

being equivalent.  Adding the method makes for cleaner code and removes the construction of a new map to call queryParamsMap.toMap().containsKey()
