### PR TITLE
Fix mimetype setting for jar resources

### DIFF
--- a/src/main/java/spark/staticfiles/MimeType.java
+++ b/src/main/java/spark/staticfiles/MimeType.java
@@ -96,8 +96,15 @@ public class MimeType {
 
     public static String fromResource(AbstractFileResolvingResource resource) {
         String filename = Optional.ofNullable(resource.getFilename()).orElse("");
+        return getMimeType(filename);
+    }
+
+    protected static String getMimeType(String filename) {
         String fileExtension = filename.replaceAll("^.*\\.(.*)$", "$1");
         return mappings.getOrDefault(fileExtension, "application/octet-stream");
     }
 
+    public static String fromPathInfo(String pathInfo) {
+        return getMimeType(pathInfo);
+    }
 }

--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -89,6 +89,7 @@ public class StaticFilesConfiguration {
                     httpResponse.setHeader(MimeType.CONTENT_TYPE, MimeType.fromResource(resource));
                     customHeaders.forEach(httpResponse::setHeader); //add all user-defined headers to response
                     OutputStream wrappedOutputStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, false);
+                    
                     IOUtils.copy(resource.getInputStream(), wrappedOutputStream);
                     wrappedOutputStream.flush();
                     wrappedOutputStream.close();
@@ -108,14 +109,13 @@ public class StaticFilesConfiguration {
                 InputStream stream = jarResourceHandler.getResource(httpRequest);
 
                 if (stream != null) {
-                    OutputStream wrappedOutputStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, false);
+                    httpResponse.setHeader(MimeType.CONTENT_TYPE, MimeType.fromPathInfo(httpRequest.getPathInfo()));
                     customHeaders.forEach(httpResponse::setHeader); //add all user-defined headers to response
+                    OutputStream wrappedOutputStream = GzipUtils.checkAndWrap(httpRequest, httpResponse, false);
 
                     IOUtils.copy(stream, wrappedOutputStream);
-
                     wrappedOutputStream.flush();
                     wrappedOutputStream.close();
-
                     return true;
                 }
             }
@@ -191,10 +191,9 @@ public class StaticFilesConfiguration {
                 jarResourceHandlers.add(new JarResourceHandler(folder, "index.html"));
                 staticResourcesSet = true;
                 return true;
-            } else {
-                LOG.error("Static file configuration failed.");
             }
-
+            
+            LOG.error("Static file configuration failed.");
         }
         return false;
     }


### PR DESCRIPTION
With Spark 2.5.1 automatic mime-type detection was introduced for static file system resources. If a static resources is being read from a jar, this mime-type detection was applied though. This pull request introduces the detection by inspecting the request pathinfo.