### PR TITLE
Make RouteImpl factory methods public

### DIFF
--- a/src/main/java/spark/RouteImpl.java
+++ b/src/main/java/spark/RouteImpl.java
@@ -39,7 +39,7 @@ public abstract class RouteImpl implements Route, Wrapper {
      * @param route the route
      * @return the wrapped route
      */
-    static RouteImpl create(final String path, final Route route) {
+    public static RouteImpl create(final String path, final Route route) {
         return create(path, DEFAULT_ACCEPT_TYPE, route);
     }
 
@@ -51,7 +51,7 @@ public abstract class RouteImpl implements Route, Wrapper {
      * @param route      the route
      * @return the wrapped route
      */
-    static RouteImpl create(final String path, String acceptType, final Route route) {
+    public static RouteImpl create(final String path, String acceptType, final Route route) {
         if (acceptType == null) {
             acceptType = DEFAULT_ACCEPT_TYPE;
         }


### PR DESCRIPTION
Same as factory methods of `ResponseTransformerRouteImpl`.

Otherwize you can't use the `Service#addRoute()` method
