### PR TITLE
Workaround for issue 684

### DIFF
--- a/src/test/java/spark/staticfiles/StaticFilesTest.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTest.java
@@ -104,6 +104,17 @@ public class StaticFilesTest {
     }
 
     @Test
+    public void testRegisteredMimeTypesForSuffixlessRegistrations() throws Exception {
+        staticFiles.registerMimeType("pageWithoutASuffix", "text/html");
+        Assert.assertEquals("text/html", doGet("/pages/pageWithoutASuffix").headers.get("Content-Type"));
+    }
+
+    @Test
+    public void testUnRegisteredMimeTypesForSuffixlessRegistrations() throws Exception {
+        Assert.assertEquals("application/octet-stream", doGet("/pages/anotherPageWithoutASuffix").headers.get("Content-Type"));
+    }
+
+    @Test
     public void testCustomMimeType() throws Exception {
         staticFiles.registerMimeType("cxt", "custom-extension-type");
         Assert.assertEquals("custom-extension-type", doGet("/img/file.cxt").headers.get("Content-Type"));

--- a/src/test/resources/public/pages/anotherPageWithoutASuffix
+++ b/src/test/resources/public/pages/anotherPageWithoutASuffix
@@ -1,0 +1,1 @@
+<html><body>Hello Static World!</body></html>

--- a/src/test/resources/public/pages/pageWithoutASuffix
+++ b/src/test/resources/public/pages/pageWithoutASuffix
@@ -1,0 +1,1 @@
+<html><body>Hello Static World!</body></html>


### PR DESCRIPTION
Tests demonstrate what you have to do with 2.5.1 and above to use suffixless static files, to avoid default mime type of 'application/octet-stream'