### PR TITLE
Guava's abstract service for awaiting stopped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
+
         <!-- LOGGING DEPENDENCIES -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/spark/Routable.java
+++ b/src/main/java/spark/Routable.java
@@ -16,13 +16,14 @@
  */
 package spark;
 
+import com.google.common.util.concurrent.AbstractService;
 import spark.route.HttpMethod;
 import spark.utils.SparkUtils;
 
 /**
  * Routable abstract class. Lets extending classes inherit default routable functionality.
  */
-abstract class Routable {
+abstract class Routable extends AbstractService {
 
     /**
      * Adds a route

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -1049,6 +1049,10 @@ public class Spark {
         getInstance().stop();
     }
 
+    public static void awaitStopped() {
+        getInstance().awaitStopped();
+    }
+
     ////////////////
     // Websockets //
 


### PR DESCRIPTION
This patch proposes to implement Spark's Service class
as an AbstractService (from Guava), which provides a
simple API to have both synchronous and asynchronous
control of the service life cycle (start, stop, etc.).

Ref: github.com/perwendel/spark/issues/705

Signed-off-by: Eduardo Bezerra <kdubezerra@gmail.com>