### PR TITLE
Add pluggable RequestLog to embedded Jetty server for use with loggers such as slf4j, log4j, etc.

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -16,6 +16,9 @@
  */
 package spark;
 
+import spark.embeddedserver.EmbeddedServerFactory;
+import spark.embeddedserver.EmbeddedServers;
+
 import static spark.Service.ignite;
 
 /**
@@ -1085,6 +1088,21 @@ public class Spark {
 
     public static void webSocket(String path, Object handler) {
         getInstance().webSocket(path, handler);
+    }
+
+    /**
+     * Adds a request log to the embedded server given the request log class.
+     * <p>
+     * This is currently only available in the embedded server mode.
+     *
+     * @param requestLog the handler class that will manage the WebSocket connection to the given path.
+     */
+    public static void requestLog(Class<?> requestLog) {
+        getInstance().requestLog(requestLog);
+    }
+
+    public static void requestLog(Object requestLog) {
+        getInstance().requestLog(requestLog);
     }
 
     /**

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
+import spark.embeddedserver.jetty.logger.RequestLogWrapper;
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.ssl.SslStores;
 
@@ -59,6 +60,16 @@ public interface EmbeddedServer {
                                      Optional<Integer> webSocketIdleTimeoutMillis) {
 
         NotSupportedException.raise(getClass().getSimpleName(), "Web Sockets");
+    }
+
+    /**
+     * Configures the request log for the embedded server.
+     *
+     * @param requestLogWrapper          - request log wrapper.
+     */
+    default void configureRequestLog(RequestLogWrapper requestLogWrapper) {
+
+        NotSupportedException.raise(getClass().getSimpleName(), "Request Log");
     }
 
     /**

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -24,7 +24,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
-import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;

--- a/src/main/java/spark/embeddedserver/jetty/logger/RequestLogClassWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/logger/RequestLogClassWrapper.java
@@ -1,0 +1,27 @@
+package spark.embeddedserver.jetty.logger;
+
+import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
+
+import static java.util.Objects.requireNonNull;
+
+public class RequestLogClassWrapper implements RequestLogWrapper {
+
+    private final Class<?> requestLogClass;
+
+    public RequestLogClassWrapper(Class<?> requestLogClass) {
+        requireNonNull(requestLogClass, "Request log class cannot be null");
+        RequestLogWrapper.validateRequestLogClass(requestLogClass);
+        this.requestLogClass = requestLogClass;
+    }
+
+
+    @Override
+    public Object getRequestLog() {
+        try {
+            return requestLogClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException ex) {
+            throw new RuntimeException("Could not instantiate request log", ex);
+        }
+    }
+
+}

--- a/src/main/java/spark/embeddedserver/jetty/logger/RequestLogClassWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/logger/RequestLogClassWrapper.java
@@ -1,7 +1,5 @@
 package spark.embeddedserver.jetty.logger;
 
-import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
-
 import static java.util.Objects.requireNonNull;
 
 public class RequestLogClassWrapper implements RequestLogWrapper {

--- a/src/main/java/spark/embeddedserver/jetty/logger/RequestLogCreatorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/logger/RequestLogCreatorFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011- Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.embeddedserver.jetty.logger;
+
+import org.eclipse.jetty.server.HandlerContainer;
+import org.eclipse.jetty.server.RequestLog;
+import org.eclipse.jetty.server.handler.RequestLogHandler;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
+import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory class to create {@link WebSocketCreator} implementations that
+ * delegate to the given handler class.
+ *
+ * @author Ignasi Barrera
+ */
+public class RequestLogCreatorFactory {
+
+    /**
+     * Creates a {@link RequestLogHandler} that uses the given request log class/instance.
+     *
+     * @param requestLogWrapper The wrapped request log to use to log requests.
+     * @return The RequestLogHandler.
+     */
+    public static RequestLogHandler create(RequestLogWrapper requestLogWrapper) {
+        RequestLogHandler requestLogHandler = new RequestLogHandler();
+        requestLogHandler.setRequestLog((RequestLog)requestLogWrapper.getRequestLog());
+        return requestLogHandler;
+    }
+}

--- a/src/main/java/spark/embeddedserver/jetty/logger/RequestLogCreatorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/logger/RequestLogCreatorFactory.java
@@ -15,18 +15,11 @@
  */
 package spark.embeddedserver.jetty.logger;
 
-import org.eclipse.jetty.server.HandlerContainer;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
-import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
-import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
-import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
-
-import static java.util.Objects.requireNonNull;
 
 /**
- * Factory class to create {@link WebSocketCreator} implementations that
+ * Factory class to create {@link RequestLogHandler} implementations that
  * delegate to the given handler class.
  *
  * @author Ignasi Barrera

--- a/src/main/java/spark/embeddedserver/jetty/logger/RequestLogInstanceWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/logger/RequestLogInstanceWrapper.java
@@ -1,0 +1,20 @@
+package spark.embeddedserver.jetty.logger;
+
+import static java.util.Objects.requireNonNull;
+
+public class RequestLogInstanceWrapper implements RequestLogWrapper {
+
+    private final Object requestLog;
+
+    public RequestLogInstanceWrapper(Object requestLog) {
+        requireNonNull(requestLog, "Request log cannot be null");
+        RequestLogWrapper.validateRequestLogClass(requestLog.getClass());
+        this.requestLog = requestLog;
+    }
+
+    @Override
+    public Object getRequestLog() {
+        return requestLog;
+    }
+
+}

--- a/src/main/java/spark/embeddedserver/jetty/logger/RequestLogWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/logger/RequestLogWrapper.java
@@ -1,0 +1,25 @@
+package spark.embeddedserver.jetty.logger;
+
+import org.eclipse.jetty.server.RequestLog;
+
+/**
+ * A wrapper for Jetty's request log
+ */
+public interface RequestLogWrapper {
+
+    /**
+     * Gets the actual handler - if necessary, instantiating an object.
+     *
+     * @return The handler instance.
+     */
+    Object getRequestLog();
+
+    static void validateRequestLogClass(Class<?> requestLogClass) {
+        boolean valid = RequestLog.class.isAssignableFrom(requestLogClass);
+        if (!valid) {
+            throw new IllegalArgumentException(
+                    "RequestLog instance must implement 'RequestLog'");
+        }
+    }
+
+}

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.Slf4jRequestLog;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
@@ -32,7 +31,18 @@ import spark.examples.exception.SubclassOfBaseException;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
-import static spark.Spark.*;
+import static spark.Spark.after;
+import static spark.Spark.before;
+import static spark.Spark.exception;
+import static spark.Spark.externalStaticFileLocation;
+import static spark.Spark.get;
+import static spark.Spark.halt;
+import static spark.Spark.patch;
+import static spark.Spark.path;
+import static spark.Spark.post;
+import static spark.Spark.requestLog;
+import static spark.Spark.staticFileLocation;
+import static spark.Spark.webSocket;
 
 public class GenericIntegrationTest {
 

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -30,17 +31,7 @@ import spark.examples.exception.SubclassOfBaseException;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
 
-import static spark.Spark.after;
-import static spark.Spark.before;
-import static spark.Spark.exception;
-import static spark.Spark.externalStaticFileLocation;
-import static spark.Spark.get;
-import static spark.Spark.halt;
-import static spark.Spark.patch;
-import static spark.Spark.path;
-import static spark.Spark.post;
-import static spark.Spark.staticFileLocation;
-import static spark.Spark.webSocket;
+import static spark.Spark.*;
 
 public class GenericIntegrationTest {
 
@@ -73,6 +64,7 @@ public class GenericIntegrationTest {
         staticFileLocation("/public");
         externalStaticFileLocation(System.getProperty("java.io.tmpdir"));
         webSocket("/ws", WebSocketTestHandler.class);
+        requestLog(NCSARequestLog.class);
 
         before("/secretcontent/*", (q, a) -> {
             halt(401, "Go Away!");

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLog;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -64,7 +65,7 @@ public class GenericIntegrationTest {
         staticFileLocation("/public");
         externalStaticFileLocation(System.getProperty("java.io.tmpdir"));
         webSocket("/ws", WebSocketTestHandler.class);
-        requestLog(NCSARequestLog.class);
+        requestLog(Slf4jRequestLog.class);
 
         before("/secretcontent/*", (q, a) -> {
             halt(401, "Go Away!");

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -2,6 +2,9 @@ package spark;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.Before;
 import org.junit.Rule;
@@ -242,4 +245,26 @@ public class ServiceTest {
     @WebSocket
     protected static class DummyWebSocketListener {
     }
+
+    @Test
+    public void testRequestLog_whenInitializedTrue_thenThrowIllegalStateException() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("This must be done before route mapping has begun");
+
+        Whitebox.setInternalState(service, "initialized", true);
+        service.requestLog(DummyRequestLog.class);
+    }
+
+    @Test
+    public void testRequestLog_whenRequestLogNull_thenThrowNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("Request log class cannot be null");
+        service.requestLog(null);
+    }
+
+    protected static class DummyRequestLog implements RequestLog {
+        @Override
+        public void log(Request request, Response response) {}
+    }
+
 }

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -2,8 +2,8 @@ package spark;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.Before;

--- a/src/test/java/spark/embeddedserver/jetty/logger/RequestLogCreatorFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/logger/RequestLogCreatorFactoryTest.java
@@ -1,0 +1,32 @@
+package spark.embeddedserver.jetty.logger;
+
+import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.handler.RequestLogHandler;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RequestLogCreatorFactoryTest {
+
+    @Test
+    public void testCreateRequestLogHandler() {
+        RequestLogHandler requestLogHandler = RequestLogCreatorFactory.create(new RequestLogClassWrapper(NCSARequestLog.class));
+        assertTrue(requestLogHandler instanceof RequestLogHandler);
+    }
+
+    @Test
+    public void testCannotCreateInvalidHandlers() {
+        try {
+            RequestLogCreatorFactory.create(new RequestLogClassWrapper(InvalidHandler.class));
+            fail("Handler creation should have thrown an IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            assertEquals(
+                    "RequestLog instance must implement 'RequestLog'",
+                    ex.getMessage());
+        }
+    }
+
+    static class InvalidHandler {
+
+    }
+}

--- a/src/test/java/spark/examples/logger/RequestLogExample.java
+++ b/src/test/java/spark/examples/logger/RequestLogExample.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2011- Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.examples.logger;
+
+import org.eclipse.jetty.server.NCSARequestLog;
+import spark.examples.websocket.EchoWebSocket;
+import spark.examples.websocket.PingWebSocket;
+
+import static spark.Spark.*;
+
+public class RequestLogExample {
+
+    public static void main(String[] args) {
+        requestLog(NCSARequestLog.class);
+        get("/log", (request, response) -> "Logged!");
+    }
+}

--- a/src/test/java/spark/examples/logger/RequestLogExample.java
+++ b/src/test/java/spark/examples/logger/RequestLogExample.java
@@ -16,7 +16,7 @@
  */
 package spark.examples.logger;
 
-import org.eclipse.jetty.server.NCSARequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLog;
 
 import static spark.Spark.get;
 import static spark.Spark.requestLog;
@@ -24,7 +24,7 @@ import static spark.Spark.requestLog;
 public class RequestLogExample {
 
     public static void main(String[] args) {
-        requestLog(NCSARequestLog.class);
+        requestLog(Slf4jRequestLog.class);
         get("/log", (request, response) -> "Logged!");
     }
 }

--- a/src/test/java/spark/examples/logger/RequestLogExample.java
+++ b/src/test/java/spark/examples/logger/RequestLogExample.java
@@ -17,10 +17,9 @@
 package spark.examples.logger;
 
 import org.eclipse.jetty.server.NCSARequestLog;
-import spark.examples.websocket.EchoWebSocket;
-import spark.examples.websocket.PingWebSocket;
 
-import static spark.Spark.*;
+import static spark.Spark.get;
+import static spark.Spark.requestLog;
 
 public class RequestLogExample {
 


### PR DESCRIPTION
Add option to specify a request log for embedded Jetty to use.

Format:
requestLog(RequestLog.class); 

this function should be called before any route mappings (similar to the websocket(...) call).
 
The provided logger should implement org.eclipse.jetty.server.RequestLog. This will allow logging of all requests, via the console, slf4j or log4j. For example, via loggers such as NCSARequestLog, Slf4jRequestLog, etc.

Sample output when running the RequestLogExample test class, using the Slf4jRequestLog:

[qtp29583191-17] INFO org.eclipse.jetty.server.RequestLog - 0:0:0:0:0:0:0:1 - - [05/Dec/2016:20:30:53 +0000] "GET //localhost:4567/log HTTP/1.1" 200 7 