### PR TITLE
New abstraction for enabling/using multipart

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ public class JsonAcceptTypeExample {
 ```
 ---------------------------------
 
-Example showing how to render a view from a template. Note that we are using `ModelAndView` class for setting the object and name/location of template. 
+Example showing how to render a view from a template. Note that we are using `ModelAndView` class for setting the object and name/tempDirectoryPath of template. 
 
 First of all we define a class which handles and renders output depending on template engine used. In this case [FreeMarker](http://freemarker.incubator.apache.org/).
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ public class JsonAcceptTypeExample {
 ```
 ---------------------------------
 
-Example showing how to render a view from a template. Note that we are using `ModelAndView` class for setting the object and name/tempDirectoryPath of template. 
+Example showing how to render a view from a template. Note that we are using `ModelAndView` class for setting the object and name/location of template. 
 
 First of all we define a class which handles and renders output depending on template engine used. In this case [FreeMarker](http://freemarker.incubator.apache.org/).
 

--- a/src/main/java/spark/multipart/MultipartConfig.java
+++ b/src/main/java/spark/multipart/MultipartConfig.java
@@ -1,0 +1,144 @@
+package spark.multipart;
+
+/**
+ * Defines the various options for configuring multipart requests/uploads.
+ */
+public class MultipartConfig {
+    private String tempDirectoryPath;
+    private long maxPartSize;
+    private long maxRequestSize;
+    private long fileSizeThreshold;
+
+    /**
+     * Creates a config with the default values that are good enough for most apps.
+     */
+    public MultipartConfig() {
+        setTempDirectoryPath("/temp");
+
+        // These are the default values Jetty uses for all 3 of these properties, so use those for now.
+        setMaxPartSize(-1);
+        setMaxRequestSize(-1);
+        setFileSizeThreshold(0);
+    }
+
+    /**
+     * The path to the temporary directory (usually something like "/temp"
+     *
+     * @return The temp directory path
+     */
+    public String getTempDirectoryPath() {
+        return tempDirectoryPath;
+    }
+
+    /**
+     * Defines the path to the temporary directory (usually something like "/temp"
+     *
+     * @param tempDirectoryPath The temp directory path
+     */
+    public void setTempDirectoryPath(String tempDirectoryPath) {
+        this.tempDirectoryPath = tempDirectoryPath;
+    }
+
+    /**
+     * The maximum size for a single part that the request will accept.
+     *
+     * @return The max size in bytes or -1 if there is no limit
+     */
+    public long getMaxPartSize() {
+        return maxPartSize;
+    }
+
+    /**
+     * Defines the maximum size for a single part that the request will accept.
+     *
+     * @param maxPartSize The max size in bytes or -1 if there is no limit
+     */
+    public void setMaxPartSize(long maxPartSize) {
+        this.maxPartSize = maxPartSize;
+    }
+
+    /**
+     * The maximum size for the entire multipart request that will be accepted
+     *
+     * @return The max size in bytes or -1 if there is no limit
+     */
+    public long getMaxRequestSize() {
+        return maxRequestSize;
+    }
+
+    /**
+     * Defines the maximum size for the entire multipart request that will be accepted
+     *
+     *  or -1 if there is no limit@param maxRequestSize The max size in bytes
+     */
+    public void setMaxRequestSize(long maxRequestSize) {
+        this.maxRequestSize = maxRequestSize;
+    }
+
+    /**
+     * Defines how many bytes a single file/part can be before we stop loading it in memory and write it to the
+     * temp directory instead.
+     *
+     * @return The file size threshold in bytes
+     */
+    public long getFileSizeThreshold() {
+        return fileSizeThreshold;
+    }
+
+    /**
+     * Defines how many bytes a single file/part can be before we stop loading it in memory and write it to the
+     * temp directory instead.
+     *
+     * @param fileSizeThreshold The file size threshold in bytes
+     */
+    public void setFileSizeThreshold(long fileSizeThreshold) {
+        this.fileSizeThreshold = fileSizeThreshold;
+    }
+
+
+    // ------ Chaining support -------------------
+
+    /**
+     * Chaining support. Defines the path ot the temp directory.
+     *
+     * @param path The temp directory path
+     * @return this
+     */
+    public MultipartConfig tempPath(String path) {
+        setTempDirectoryPath(path);
+        return this;
+    }
+
+    /**
+     * Chaining support. Defines the maximum size of a single part.
+     *
+     * @param size The size in bytes
+     * @return this
+     */
+    public MultipartConfig maxPartSize(long size) {
+        setMaxPartSize(size);
+        return this;
+    }
+
+    /**
+     * Chaining support. Defines the maximum size of an entire multipart request.
+     *
+     * @param size The size in bytes
+     * @return this
+     */
+    public MultipartConfig maxRequestSize(long size) {
+        setMaxRequestSize(size);
+        return this;
+    }
+
+    /**
+     * Chaining support. Defines the maximum size of an entire multipart request.
+     *
+     * @param size The size in bytes
+     * @return this
+     */
+    public MultipartConfig fileThreshold(long size) {
+        setFileSizeThreshold(size);
+        return this;
+    }
+}

--- a/src/main/java/spark/multipart/MultipartPart.java
+++ b/src/main/java/spark/multipart/MultipartPart.java
@@ -1,0 +1,80 @@
+package spark.multipart;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * When using HTTP(S) to upload files to the web server you typically encode the binary data as a "multipart" request
+ * where the Content-Type is something like "multipart/XXX; YYY=ZZZ". Most web frameworks like Jetty support
+ * abstractions to pick decode and pick apart these "parts" of the request.
+ * <br/>
+ * A MultipartPart encapsulates a single part of the multipart request, standardizing how you access things such as the
+ * name of the part, its content type, and the raw data for that part. Regardless of the underlying web server Spark
+ * will provide these standard accessors for the multipart data.
+ * <br/>
+ * This interface is AutoCloseable so that you can use your parts in Try-With-Resources blocks to safely clean up any
+ * streams/resources associated with this Blob of data.
+ */
+public interface MultipartPart extends AutoCloseable {
+
+    /**
+     * This is the actual "name" of the part. This is NOT necessarily unique across multiple parts within the same
+     * request as it is perfectly legal to submit multiple parts named "attachments[]". In cases like that Spark will
+     * generate a separate MultipartPart instance for each one, but they'll have have the name "attachments[]".
+     *
+     * @return The name of the part submitted w/ the request
+     */
+    String name();
+
+    /**
+     * When constructing a multipart request, you can include the name of the original file that this part represents.
+     * So if you're handing a file upload you can send "my-dogs.jpg" along with the part name and data. This field
+     * is completely optional and has no "trusted" meaning.
+     * <br/>
+     * SECURITY WARNING: Do not use this file name as-is in your application if you are going to save this data to
+     * a file system somewhere. Someone, for instance, could submit a "picture" named "/usr/bin/vi" which is actually
+     * some malicious binary. If you save the filename as is, bad things are likely to happen, so if you do intend to use
+     * this field for persistent paths, make sure to sanitize the file name first.
+     *
+     * @return The name of the original file that this part represents
+     */
+    String fileName();
+
+    /**
+     * Retrieves the MIME type of the data encoded in this part.
+     *
+     * @return The MIME type
+     */
+    String contentType();
+
+    /**
+     * Retrieves the total number of bytes encoded in this part.
+     *
+     * @return The length of the stream in bytes
+     */
+    long contentLength();
+
+    /**
+     * Retrieves the decoded part data as a raw stream of bytes. This stream is lazy-loaded so if you don't access the
+     * stream you don't need to do anything with it. If you do access this stream it is up to you to properly close it later.
+     *
+     * @return The raw data stream
+     */
+    InputStream inputStream() throws IOException;
+
+    /**
+     * Completely reads the decoded data as a UTF-8 String. The underlying stream will be closed after this operation
+     * is finished.
+     *
+     * @return The part data as a string.
+     */
+    String asString();
+
+    /**
+     * Completely reads the decoded data as a raw byte array. The underlying stream will be closed after this operation
+     * is finished.
+     *
+     * @return The part data as a byte array.
+     */
+    byte[] asBytes();
+}

--- a/src/main/java/spark/multipart/ServletMultipartPart.java
+++ b/src/main/java/spark/multipart/ServletMultipartPart.java
@@ -1,0 +1,136 @@
+package spark.multipart;
+
+import spark.utils.IOUtils;
+import spark.utils.ObjectUtils;
+
+import javax.servlet.http.Part;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Encapsulates the standard Servlet multipart "Part" as the source for a Spark MultipartPart. Should Spark decide to
+ * offer non-servlet based HTTP web engines then Request will need to create a different instance of MultipartPart to
+ * carry the load.
+ */
+public class ServletMultipartPart implements MultipartPart {
+
+    // Haha... private part. Don't act like you aren't snickering at that!
+    private Part part;
+    private InputStream stream;
+
+    // Capture the various auto-converted formats if you don't use the stream directly to protect against multiple calls
+    private byte[] streamBytes;
+    private String streamString;
+
+    public ServletMultipartPart(Part part) {
+        this.part = part;
+    }
+
+    /**
+     * This is the actual "name" of the part. This is NOT necessarily unique across multiple parts within the same
+     * request as it is perfectly legal to submit multiple parts named "attachments[]". In cases like that Spark will
+     * generate a separate MultipartPart instance for each one, but they'll have have the name "attachments[]".
+     *
+     * @return The name of the part submitted w/ the request
+     */
+    @Override
+    public String name() {
+        return part.getName();
+    }
+
+    /**
+     * When constructing a multipart request, you can include the name of the original file that this part represents.
+     * So if you're handing a file upload you can send "my-dogs.jpg" along with the part name and data. This field
+     * is completely optional and has no "trusted" meaning.
+     * <br/>
+     * SECURITY WARNING: Do not use this file name as-is in your application if you are going to save this data to
+     * a file system somewhere. Someone, for instance, could submit a "picture" named "/usr/bin/vi" which is actually
+     * some malicious binary. If you save the filename as is, bad things are likely to happen, so if you do intend to use
+     * this field for persistent paths, make sure to sanitize the file name first.
+     *
+     * @return The name of the original file that this part represents
+     */
+    @Override
+    public String fileName() {
+        return part.getSubmittedFileName();
+    }
+
+    /**
+     * Retrieves the MIME type of the data encoded in this part.
+     *
+     * @return The MIME type
+     */
+    @Override
+    public String contentType() {
+        return part.getContentType();
+    }
+
+    /**
+     * Retrieves the total number of bytes encoded in this part.
+     *
+     * @return The length of the stream in bytes
+     */
+    @Override
+    public long contentLength() {
+        return part.getSize();
+    }
+
+    /**
+     * Retrieves the decoded part data as a raw stream of bytes. This stream is lazy-loaded so if you don't access the
+     * stream you don't need to do anything with it. If you do access this stream it is up to you to properly close it later.
+     *
+     * @return The raw data stream
+     */
+    @Override
+    public InputStream inputStream() throws IOException {
+        return (stream == null)
+            ? stream = part.getInputStream()
+            : stream;
+    }
+
+    /**
+     * Completely reads the decoded data as a UTF-8 String. The underlying stream will be closed after this operation
+     * is finished.
+     *
+     * @return The part data as a string.
+     */
+    @Override
+    public String asString() {
+        if (streamString == null) {
+            try (InputStream input = inputStream()) {
+                streamString = (input == null) ? "" : IOUtils.toString(input);
+            }
+            catch (IOException ioe) {
+                streamString = "";
+            }
+        }
+        return streamString;
+    }
+
+    /**
+     * Completely reads the decoded data as a raw byte array. The underlying stream will be closed after this operation
+     * is finished.
+     *
+     * @return The part data as a byte array. If an error occurs you'll receive a 0-length array, not null.
+     */
+    @Override
+    public byte[] asBytes() {
+        if (streamBytes == null) {
+            try (InputStream input = inputStream()) {
+                streamBytes = (input == null) ? new byte[0] : IOUtils.toByteArray(input);
+            }
+            catch (IOException ioe) {
+                streamBytes = new byte[0];
+            }
+        }
+        return streamBytes;
+    }
+
+    /**
+     * Closes our underlying data stream if we opened it and haven't yet closed it
+     */
+    @Override
+    public void close() throws Exception {
+        ObjectUtils.closeQuietly(stream);
+    }
+}

--- a/src/main/java/spark/utils/CollectionUtils.java
+++ b/src/main/java/spark/utils/CollectionUtils.java
@@ -17,6 +17,7 @@
 package spark.utils;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Miscellaneous collection utility methods.
@@ -42,4 +43,15 @@ public abstract class CollectionUtils {
         return (collection == null || collection.isEmpty());
     }
 
+    /**
+     * A null-safe way to call <code>.stream()</code> on a collection. Null collections result in empty streams.
+     *
+     * @param collection The collection whose stream of elements you want
+     * @return A non-null stream (may be empty though).
+     */
+    public static <T> Stream<T> stream(Collection<T> collection) {
+        return (collection == null)
+            ? Stream.empty()
+            : collection.stream();
+    }
 }

--- a/src/main/java/spark/utils/ObjectUtils.java
+++ b/src/main/java/spark/utils/ObjectUtils.java
@@ -41,4 +41,18 @@ public abstract class ObjectUtils {
         return (array == null || array.length == 0);
     }
 
+    /**
+     * A null-safe, quiet way to close an auto-closable resource. This will swallow any exceptions without so
+     * much as a log line so make sure that if you want quiet that you really want quiet.
+     * @param resource The resource to close.
+     */
+    public static void closeQuietly(AutoCloseable resource) {
+        try {
+            if (resource != null)
+                resource.close();
+        }
+        catch (Exception e) {
+            /* Gobble it up since it's supposed to be "quiet" */
+        }
+    }
 }

--- a/src/test/java/spark/multipart/ServletMultipartPartTest.java
+++ b/src/test/java/spark/multipart/ServletMultipartPartTest.java
@@ -1,0 +1,183 @@
+package spark.multipart;
+
+import org.apache.commons.codec.Charsets;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.Part;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServletMultipartPartTest {
+    private Part servletPart;
+    private ServletMultipartPart part;
+
+    @Before
+    public void beforeTest() {
+        // Each test will use a servlet part but will define its own attributes as needed
+        servletPart = mock(Part.class);
+        part = new ServletMultipartPart(servletPart);
+    }
+
+    @Test
+    public void testName() {
+        final String name = "foo";
+
+        when(servletPart.getName()).thenReturn(name);
+
+        assertEquals(name, part.name());
+    }
+
+    @Test
+    public void testFileName_null() {
+        when(servletPart.getSubmittedFileName()).thenReturn(null);
+
+        assertNull(part.fileName());
+    }
+
+    @Test
+    public void testFileName_valid() {
+        final String fileName = "foo.bar.zip";
+
+        when(servletPart.getSubmittedFileName()).thenReturn(fileName);
+
+        assertEquals(fileName, part.fileName());
+    }
+
+    @Test
+    public void testContentType_null() {
+        when(servletPart.getContentType()).thenReturn(null);
+
+        assertNull(part.contentType());
+    }
+
+    @Test
+    public void testContentType_simple() {
+        final String type = "application/json";
+
+        when(servletPart.getContentType()).thenReturn(type);
+
+        assertEquals(type, part.contentType());
+    }
+
+    @Test
+    public void testContentType_withBoundary() {
+        final String type = "multipart/form-data; boundary=aabbcc00";
+
+        when(servletPart.getContentType()).thenReturn(type);
+
+        assertEquals(type, part.contentType());
+    }
+
+    @Test
+    public void testContentLength_zero() {
+        final long length = 0;
+
+        when(servletPart.getSize()).thenReturn(length);
+
+        assertEquals(length, part.contentLength());
+    }
+
+    @Test
+    public void testContentLength_nonZero() {
+        final long length = 1024;
+
+        when(servletPart.getSize()).thenReturn(length);
+
+        assertEquals(length, part.contentLength());
+    }
+
+    @Test
+    public void testStream_nullStream() throws Exception {
+        when(servletPart.getInputStream()).thenReturn(null);
+
+        assertNull(part.inputStream());
+    }
+
+    @Test
+    public void testStream_validStream() throws Exception {
+        final InputStream stream = new ByteArrayInputStream(new byte[0]);
+
+        when(servletPart.getInputStream()).thenReturn(stream);
+
+        assertTrue(part.inputStream() == stream);
+    }
+
+    @Test
+    public void testAsString_nullStream() throws Exception {
+        when(servletPart.getInputStream()).thenReturn(null);
+
+        assertEquals("", part.asString());
+    }
+
+    @Test
+    public void testAsString_validString() throws Exception {
+        final String text = "The foo'est, bar'est, baz'iest of them all.";
+        final InputStream stream = new ByteArrayInputStream(text.getBytes(Charsets.UTF_8));
+
+        when(servletPart.getInputStream()).thenReturn(stream);
+
+        assertEquals(text, part.asString());
+    }
+
+    @Test
+    public void testAsString_multipleCalls() throws Exception {
+        final String text = "Foo";
+        final InputStream stream = new ByteArrayInputStream(text.getBytes(Charsets.UTF_8));
+
+        when(servletPart.getInputStream()).thenReturn(stream);
+
+        // Shouldn't re-read the byte array, so if no IOException is thrown then we're good
+        assertEquals(text, part.asString());
+        assertEquals(text, part.asString());
+    }
+
+    @Test
+    public void testAsString_swallowException() throws Exception {
+        when(servletPart.getInputStream()).thenThrow(new IOException());
+
+        assertEquals("", part.asString());
+    }
+
+    @Test
+    public void testAsBytes_null() throws Exception {
+        when(servletPart.getInputStream()).thenReturn(null);
+
+        assertArrayEquals(new byte[0], part.asBytes());
+    }
+
+    @Test
+    public void testAsBytes_validBytes() throws Exception {
+        final byte[] bytes = new byte[] { (byte)1, (byte)2, (byte)3 };
+        final InputStream stream = new ByteArrayInputStream(bytes);
+
+        when(servletPart.getInputStream()).thenReturn(stream);
+
+        assertArrayEquals(bytes, part.asBytes());
+    }
+
+    @Test
+    public void testAsBytes_multipleCalls() throws Exception {
+        final byte[] bytes = new byte[] { (byte)1, (byte)2, (byte)3 };
+        final InputStream stream = new ByteArrayInputStream(bytes);
+
+        when(servletPart.getInputStream()).thenReturn(stream);
+
+        // Should return the same array regardless of how many times you call 'asBytes()'
+        assertArrayEquals(bytes, part.asBytes());
+        assertArrayEquals(bytes, part.asBytes());
+    }
+
+    @Test
+    public void testAsBytes_swallowException() throws Exception {
+        when(servletPart.getInputStream()).thenThrow(new IOException());
+
+        assertArrayEquals(new byte[0], part.asBytes());
+    }
+}

--- a/src/test/java/spark/utils/CollectionUtilsTest.java
+++ b/src/test/java/spark/utils/CollectionUtilsTest.java
@@ -3,7 +3,11 @@ package spark.utils;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
 
@@ -26,5 +30,26 @@ public class CollectionUtilsTest {
 
         assertFalse("Should return false because collection is empty", CollectionUtils.isEmpty(testCollection));
 
+    }
+
+    @Test
+    public void testStream_null() {
+        Stream<?> stream = CollectionUtils.stream(null);
+
+        assertNotNull(stream);
+        assertEquals(0, stream.count());
+    }
+
+    @Test
+    public void testStream_list() {
+        List<String> items = Arrays.asList("foo", "bar", "baz");
+
+        // Make sure you get something back
+        Stream<String> stream = CollectionUtils.stream(items);
+        assertNotNull(stream);
+
+        // Make sure the stream contains the same items
+        List<String> streamedItems = stream.collect(Collectors.toList());
+        assertTrue(items.equals(streamedItems));
     }
 }

--- a/src/test/java/spark/utils/ObjectUtilsTest.java
+++ b/src/test/java/spark/utils/ObjectUtilsTest.java
@@ -2,7 +2,9 @@ package spark.utils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 public class ObjectUtilsTest {
 
@@ -18,5 +20,27 @@ public class ObjectUtilsTest {
 
         assertFalse("Should return false because array is not empty", ObjectUtils.isEmpty(new Integer[]{1,2}));
 
+    }
+
+    @Test
+    public void testCloseQuietly_null() {
+        // Success is not throwing an exception so there's no "assertion" other than not expecting an exception
+        ObjectUtils.closeQuietly(null);
+    }
+
+    @Test
+    public void testCloseQuietly_open() throws Exception {
+        // Success is not throwing an exception so there's no "assertion" other than not expecting an exception
+        AutoCloseable closeable = mock(AutoCloseable.class);
+        doNothing().when(closeable).close();
+        ObjectUtils.closeQuietly(closeable);
+    }
+
+    @Test
+    public void testCloseQuietly_closed() throws Exception {
+        // Success is not throwing an exception so there's no "assertion" other than not expecting an exception
+        AutoCloseable closeable = mock(AutoCloseable.class);
+        doThrow(new IllegalStateException("Already closed")).when(closeable).close();
+        ObjectUtils.closeQuietly(closeable);
     }
 }


### PR DESCRIPTION
This is a contribution for issue #543. While the issue asked for a more seamless way to enable multipart, I took it a step further and encapsulated the whole multipart experience into a new abstraction. Instead of interacting w/ the raw Jetty/servlet "Part" instance, I've added a separate class that lets users stay at the Spark level.

```java
Spark.post("/my/file/upload", (req, res) => {
    // Not required, but part() returns null and parts() returns empty if not true
    if (!req.isMultpart()) {
        throw new RuntimeException("Not a multipart content type");
    }

    try (MultipartPart foo = req.part("foo.txt");
         MultipartPart bar = req.part("bar.png")) {
        String fooText = foo.asText();
        InputStream barStream = bar.inputStream();  // auto-closed when part is closed via try w/ resources
       ... do something interesting ...
    }
});
```

There are 3 ways to access parts

```java
// Grab the part/file w/ the specific part name
MultipartPart foo = req.part("foo");

// Multiple parts/files uploaded w/ the same part name
Collection<MultipartPart> allBars = req.parts("bar");

// Grab all parts/files from the request
Collection<MultipartPart> everything = req.parts();
```

Some of the benefits of this approach/implementation:

* The jetty request attribute is automatically lazy-set when you make your first call to ```part()``` or either of the ```parts(String)``` overloads. One less thing for the programmer to think about. You can specify your own value if you care to beforehand but it's no longer a requirement as it will default to "/temp" just like in the docs.
* MultipartPart is auto closable so we can use try-with-resources to better make sure that we're cleaning up all of our data streams when the request is finished.
* Removes the need to dip into the raw servlet request. Perhaps I'm a purist but the more I can stay in Spark-land and not have to dive into Jetty/Servlet-land the better off I feel. The additional request methods match Spark's existing style for interacting with the request so it feels more natural to me.
* Not sure if it's a desire for Spark to support pluggable HTTP engines at some point in the future, but if so, this implementation is no longer as tightly coupled to Jetty's implementation. Between the ```MultipartConfig``` class and ```MultipartPart``` being an interface w/ a servlet reference implementation, it should be easy to swap out web server specific implementations should you choose to do that.

I've included a series of unit tests for these classes and updated the tests for the util classes I updated. Hopefully you find this a useful addition to Spark.