### PR TITLE
Fix #714

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -457,6 +457,11 @@ public final class Service extends Routable {
                             maxThreads,
                             minThreads,
                             threadIdleTimeoutMillis);
+                    try {
+                        server.join();
+                    } catch (InterruptedException e) {
+                        LOG.error("server interrupted", e);
+                    }
                 }).start();
             }
             initialized = true;

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -453,11 +453,11 @@ public final class Service extends Routable {
                             ipAddress,
                             port,
                             sslStores,
-                            latch,
                             maxThreads,
                             minThreads,
                             threadIdleTimeoutMillis);
                     try {
+                        latch.countDown();
                         server.join();
                     } catch (InterruptedException e) {
                         LOG.error("server interrupted", e);

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -461,6 +461,7 @@ public final class Service extends Routable {
                         server.join();
                     } catch (InterruptedException e) {
                         LOG.error("server interrupted", e);
+                        Thread.currentThread().interrupt();
                     }
                 }).start();
             }

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -18,7 +18,6 @@ package spark.embeddedserver;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.ssl.SslStores;
@@ -35,7 +34,6 @@ public interface EmbeddedServer {
      * @param host                    The address to listen on
      * @param port                    - the port
      * @param sslStores               - The SSL sslStores.
-     * @param latch                   - the countdown latch
      * @param maxThreads              - max nbr of threads.
      * @param minThreads              - min nbr of threads.
      * @param threadIdleTimeoutMillis - idle timeout (ms).
@@ -44,7 +42,6 @@ public interface EmbeddedServer {
     int ignite(String host,
                int port,
                SslStores sslStores,
-               CountDownLatch latch,
                int maxThreads,
                int minThreads,
                int threadIdleTimeoutMillis);

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -62,6 +62,11 @@ public interface EmbeddedServer {
     }
 
     /**
+     * Joins the embedded server thread(s).
+     */
+    void join() throws InterruptedException;
+
+    /**
      * Extinguish the embedded server.
      */
     void extinguish();

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
@@ -75,7 +74,6 @@ public class EmbeddedJettyServer implements EmbeddedServer {
     public int ignite(String host,
                       int port,
                       SslStores sslStores,
-                      CountDownLatch latch,
                       int maxThreads,
                       int minThreads,
                       int threadIdleTimeoutMillis) {
@@ -127,7 +125,6 @@ public class EmbeddedJettyServer implements EmbeddedServer {
             logger.info(">> Listening on {}:{}", host, port);
 
             server.start();
-            latch.countDown();
         } catch (Exception e) {
             logger.error("ignite failed", e);
             System.exit(100);

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -128,13 +128,20 @@ public class EmbeddedJettyServer implements EmbeddedServer {
 
             server.start();
             latch.countDown();
-            server.join();
         } catch (Exception e) {
             logger.error("ignite failed", e);
             System.exit(100);
         }
 
         return port;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void join() throws InterruptedException {
+        server.join();
     }
 
     /**

--- a/src/test/java/spark/ServicePortIntegrationTest.java
+++ b/src/test/java/spark/ServicePortIntegrationTest.java
@@ -1,0 +1,42 @@
+package spark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+
+import static spark.Service.ignite;
+
+/**
+ * Created by Tom on 08/02/2017.
+ */
+public class ServicePortIntegrationTest {
+
+    private static Service service;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        service = ignite();
+        service.port(0);
+
+        service.get("/hi", (q, a) -> "Hello World!");
+
+        service.awaitInitialization();
+    }
+
+    @Test
+    public void testGetPort_withRandomPort() throws Exception {
+        int actualPort = service.port();
+        SparkTestUtil testUtil = new SparkTestUtil(actualPort);
+
+        SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hi", null);
+        Assert.assertEquals(200, response.status);
+        Assert.assertEquals("Hello World!", response.body);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        service.stop();
+    }
+}

--- a/src/test/java/spark/ServicePortIntegrationTest.java
+++ b/src/test/java/spark/ServicePortIntegrationTest.java
@@ -4,7 +4,10 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.util.SparkTestUtil;
+import sun.rmi.runtime.Log;
 
 import static spark.Service.ignite;
 
@@ -14,6 +17,7 @@ import static spark.Service.ignite;
 public class ServicePortIntegrationTest {
 
     private static Service service;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServicePortIntegrationTest.class);
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -28,6 +32,9 @@ public class ServicePortIntegrationTest {
     @Test
     public void testGetPort_withRandomPort() throws Exception {
         int actualPort = service.port();
+
+        LOGGER.info("got port ");
+
         SparkTestUtil testUtil = new SparkTestUtil(actualPort);
 
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/hi", null);


### PR DESCRIPTION
Calling port() after setting port(0) now returns the correct port
Joining the embedded server can be done with the join method