### PR TITLE
Expose active server thread count

### DIFF
--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -65,4 +65,10 @@ public interface EmbeddedServer {
      * Extinguish the embedded server.
      */
     void extinguish();
+
+    /**
+     *
+     * @return The approximate number of currently active threads
+     */
+    int getActiveThreadCount();
 }

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -154,5 +154,12 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         logger.info("done");
     }
 
+    @Override
+    public int getActiveThreadCount() {
+        if (server != null) {
+            return 0;
+        }
 
+        return server.getThreadPool().getThreads() - server.getThreadPool().getIdleThreads();
+    }
 }


### PR DESCRIPTION
Is there any interest to expose data like this?

Exposing this would allow monitoring the current server threads. I'd like to use that data to fine tune the server threads configuration.