### PR TITLE
Make RouteOverview work in Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,10 +190,6 @@
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
-                    <excludes>
-                        <exclude>**/spark/route/RouteOverviewTest.java</exclude>
-                        <!-- Test works in IntelliJ, functionality works in jar, but this fails during mvn install -->
-                    </excludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/spark/route/RouteOverview.java
+++ b/src/main/java/spark/route/RouteOverview.java
@@ -16,17 +16,12 @@
  */
 package spark.route;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import spark.Request;
 import spark.Response;
 import spark.utils.Wrapper;
-import sun.reflect.ConstantPool;
 
 import static java.util.Collections.singletonList;
 import static spark.Spark.get;
@@ -70,7 +65,7 @@ public class RouteOverview {
 
     static String createHtmlOverview(Request request, Response response) {
         String head = "<meta name='viewport' content='width=device-width, initial-scale=1'>"
-                + "<style>b,thead{font-weight:700}body{font-family:monospace;padding:15px}table{border-collapse:collapse;font-size:14px;border:1px solid #d5d5d5;width:100%;white-space:pre}thead{background:#e9e9e9;border-bottom:1px solid #d5d5d5}tbody tr:hover{background:#f5f5f5}td{padding:6px 15px}b{color:#33D}em{color:#666}</style>";
+            + "<style>b,thead{font-weight:700}body{font-family:monospace;padding:15px}table{border-collapse:collapse;font-size:14px;border:1px solid #d5d5d5;width:100%;white-space:pre}thead{background:#e9e9e9;border-bottom:1px solid #d5d5d5}tbody tr:hover{background:#f5f5f5}td{padding:6px 15px}b{color:#33D}em{color:#666}</style>";
 
         String rowTemplate = "<tr><td>%s</td><td>%s</td><td><b>%s</b></td><td>%s</td></tr>";
 
@@ -88,19 +83,17 @@ public class RouteOverview {
 
         if (routeStr.contains("$$Lambda$")) { // This is a Route or Filter lambda
 
-            Map<Object, String> fieldNames = fieldNames(routeTarget);
-            String className = routeStr.split("\\$")[0];
-
-            if (fieldNames.containsKey(routeTarget)) { // Lambda name has been mapped in fieldNameMap
-                return className + "<b>." + fieldNames.get(routeTarget) + "</b> <em>(field)</em>";
+            // strip instance ref from routeStr
+            String[] split = routeStr.split("/");
+            if (split.length == 0) {
+                return "<b>???</b> <em>(lambda)</em>";
             }
+            String withoutInstanceRef = split[0];
 
-            if (!methodName(routeTarget).contains("lambda$")) { // Method has name (is not anonymous lambda)
-                return className(routeTarget) + "<b>::" + methodName(routeTarget)
-                        + "</b> <em>(method reference)</em>";
-            }
+            String packages = withoutInstanceRef.split("@")[0].substring(0, withoutInstanceRef.lastIndexOf("."));
+            String className = withoutInstanceRef.split("@")[0].substring(withoutInstanceRef.lastIndexOf(".") + 1);
 
-            return className + "<b>???</b> <em>(anonymous lambda)</em>";
+            return packages + ".<b>" + className + ".class</b> <em>(lambda)</em>";
         }
 
         if (routeStr.contains("@")) { // This is a Class implementing Route or Filter
@@ -110,44 +103,6 @@ public class RouteOverview {
         }
 
         return "<b>Mysterious route handler</b>";
-    }
-
-    private static Map<Object, String> fieldNames(Object routeTarget) {
-        Map<Object, String> fieldNames = new HashMap<>();
-
-        try {
-            Class clazz = Class.forName(className(routeTarget));
-
-            for (Field field : clazz.getDeclaredFields()) {
-                field.setAccessible(true);
-                fieldNames.put(field.get(field), field.getName());
-            }
-
-        } catch (Exception ignored) { // Nothing really matters.
-        }
-
-        return fieldNames;
-    }
-
-    private static String className(Object routeTarget) {
-        return methodRefInfo(routeTarget)[0].replace("/", ".");
-    }
-
-    private static String methodName(Object routeTarget) {
-        return methodRefInfo(routeTarget)[1];
-    }
-
-    private static String[] methodRefInfo(Object routeTarget) {
-        try {
-            // This is some robustified shit right here.
-            Method getConstantPool = Class.class.getDeclaredMethod("getConstantPool");
-            getConstantPool.setAccessible(true);
-
-            ConstantPool constantPool = (ConstantPool) getConstantPool.invoke(routeTarget.getClass());
-            return constantPool.getMemberRefInfoAt(constantPool.getSize() - 2);
-        } catch (Exception e) {
-            return new String[] {"", ""};
-        }
     }
 
 }

--- a/src/test/java/spark/route/RouteOverviewTest.java
+++ b/src/test/java/spark/route/RouteOverviewTest.java
@@ -62,7 +62,7 @@ public class RouteOverviewTest {
 
     @Test
     public void assertThat_filter_field_works() {
-        assertThat(routeName(FILTER_FIELD), containsString("RouteOverviewTest.filterField"));
+        assertThat(routeName(FILTER_FIELD), containsString("RouteOverviewTest$$Lambda"));
     }
 
     @Test
@@ -72,17 +72,17 @@ public class RouteOverviewTest {
 
     @Test
     public void assertThat_filter_methodRef_works() {
-        assertThat(routeName(FILTER_METHOD_REF), containsString("RouteOverviewTest::filterMethodRef"));
+        assertThat(routeName(FILTER_METHOD_REF), containsString("RouteOverviewTest$$Lambda"));
     }
 
     @Test
     public void assertThat_filter_lambda_works() {
-        assertThat(routeName(FILTER_LAMBDA), containsString("RouteOverviewTest???"));
+        assertThat(routeName(FILTER_LAMBDA), containsString("RouteOverviewTest$$Lambda"));
     }
 
     @Test
     public void assertThat_route_field_works() {
-        assertThat(routeName(ROUTE_FIELD), containsString("RouteOverviewTest.routeField"));
+        assertThat(routeName(ROUTE_FIELD), containsString("RouteOverviewTest$$Lambda"));
     }
 
     @Test
@@ -92,12 +92,12 @@ public class RouteOverviewTest {
 
     @Test
     public void assertThat_route_methodRef_works() {
-        assertThat(routeName(ROUTE_METHOD_REF), containsString("RouteOverviewTest::routeMethodRef"));
+        assertThat(routeName(ROUTE_METHOD_REF), containsString("RouteOverviewTest$$Lambda"));
     }
 
     @Test
     public void assertThat_route_lambda_works() {
-        assertThat(routeName(ROUTE_LAMBDA), containsString("RouteOverviewTest???"));
+        assertThat(routeName(ROUTE_LAMBDA), containsString("RouteOverviewTest$$Lambda"));
     }
 
     // fields/classes/methods to obtain names from

--- a/src/test/java/spark/staticfiles/StaticFilesTest.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTest.java
@@ -139,7 +139,7 @@ public class StaticFilesTest {
 
     @Test
     public void testDirectoryTraversalProtectionLocal() throws Exception {
-        String path = "/" + URLEncoder.encode("..\\spark\\") + "Spark.class";
+        String path = "/" + URLEncoder.encode("..\\spark\\", "UTF-8") + "Spark.class";
         SparkTestUtil.UrlResponse response = doGet(path);
 
         Assert.assertEquals(404, response.status);

--- a/src/test/java/spark/staticfiles/StaticFilesTestExternal.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTestExternal.java
@@ -118,7 +118,7 @@ public class StaticFilesTestExternal {
 
     @Test
     public void testDirectoryTraversalProtectionExternal() throws Exception {
-        String path = "/" + URLEncoder.encode("..\\..\\spark\\") + "Spark.class";
+        String path = "/" + URLEncoder.encode("..\\..\\spark\\", "UTF-8") + "Spark.class";
         SparkTestUtil.UrlResponse response = doGet(path);
 
         Assert.assertEquals(404, response.status);


### PR DESCRIPTION
I've simplified how the RouteOverview handles lambdas. It is a small step back in functionality, but  allows Spark to compile in Java 9. A positive side-effect: this commit removes the need for a build workaround that was present in pom.xml.

