### PR TITLE
Made minor changes to avoid compiler warnings

### DIFF
--- a/src/test/java/spark/ServicePortIntegrationTest.java
+++ b/src/test/java/spark/ServicePortIntegrationTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.util.SparkTestUtil;
-import sun.rmi.runtime.Log;
 
 import static spark.Service.ignite;
 

--- a/src/test/java/spark/staticfiles/StaticFilesTest.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTest.java
@@ -139,7 +139,7 @@ public class StaticFilesTest {
 
     @Test
     public void testDirectoryTraversalProtectionLocal() throws Exception {
-        String path = "/" + URLEncoder.encode("..\\spark\\") + "Spark.class";
+        String path = "/" + URLEncoder.encode("..\\spark\\", "UTF-8") + "Spark.class";
         SparkTestUtil.UrlResponse response = doGet(path);
 
         Assert.assertEquals(404, response.status);

--- a/src/test/java/spark/staticfiles/StaticFilesTestExternal.java
+++ b/src/test/java/spark/staticfiles/StaticFilesTestExternal.java
@@ -118,7 +118,7 @@ public class StaticFilesTestExternal {
 
     @Test
     public void testDirectoryTraversalProtectionExternal() throws Exception {
-        String path = "/" + URLEncoder.encode("..\\..\\spark\\") + "Spark.class";
+        String path = "/" + URLEncoder.encode("..\\..\\spark\\", "UTF-8") + "Spark.class";
         SparkTestUtil.UrlResponse response = doGet(path);
 
         Assert.assertEquals(404, response.status);


### PR DESCRIPTION
* Removed unused import that caused compiler warning
* Replaced use of deprecated URLEncoder.encode(String s) method with URLEncoder.encode(String s, String enc) alternative.
