### PR TITLE
Adding a method to configure maximum allowed http headers size

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -986,6 +986,18 @@ public class Spark {
     }
 
     /**
+     * Sets the maximum size of both accepted request headers and response headers.
+     * This has to be called before any route mapping is done.
+     * If not called, maximum size of headers is set to 8192 bytes, as defined in
+     * {@see Service.SPARK_DEFAULT_MAX_HEADERS_SIZE}.
+     *
+     * @param maxHeaderSize Maximum headers size in bytes
+     */
+    public static void maxHeadersSize(final int maxHeaderSize) {
+        getInstance().maxHeadersSize(maxHeaderSize);
+    }
+
+    /**
      * Set the connection to be secure, using the specified keystore and
      * truststore. This has to be called before any route mapping is done. You
      * have to supply a keystore file, truststore file is optional (keystore

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -16,11 +16,11 @@
  */
 package spark.embeddedserver;
 
-import java.util.Map;
-import java.util.Optional;
-
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.ssl.SslStores;
+
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represents an embedded server that can be used in Spark. (this is currently Jetty by default).
@@ -37,6 +37,7 @@ public interface EmbeddedServer {
      * @param maxThreads              - max nbr of threads.
      * @param minThreads              - min nbr of threads.
      * @param threadIdleTimeoutMillis - idle timeout (ms).
+     * @param maxHeadersSize          - maximum size of http request/response headers.
      * @return The port number the server was launched on.
      */
     int ignite(String host,
@@ -44,7 +45,8 @@ public interface EmbeddedServer {
                SslStores sslStores,
                int maxThreads,
                int minThreads,
-               int threadIdleTimeoutMillis);
+               int threadIdleTimeoutMillis,
+               int maxHeadersSize);
 
     /**
      * Configures the web sockets for the embedded server.

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -16,13 +16,6 @@
  */
 package spark.embeddedserver.jetty;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -31,11 +24,17 @@ import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.embeddedserver.jetty.websocket.WebSocketServletContextHandlerFactory;
 import spark.ssl.SslStores;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Spark server implementation
@@ -76,7 +75,8 @@ public class EmbeddedJettyServer implements EmbeddedServer {
                       SslStores sslStores,
                       int maxThreads,
                       int minThreads,
-                      int threadIdleTimeoutMillis) {
+                      int threadIdleTimeoutMillis,
+                      int maxHeadersSize) {
 
         if (port == 0) {
             try (ServerSocket s = new ServerSocket(0)) {
@@ -92,9 +92,9 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         ServerConnector connector;
 
         if (sslStores == null) {
-            connector = SocketConnectorFactory.createSocketConnector(server, host, port);
+            connector = SocketConnectorFactory.createSocketConnector(server, host, port, maxHeadersSize);
         } else {
-            connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores);
+            connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores, maxHeadersSize);
         }
 
         server = connector.getServer();

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -1,15 +1,14 @@
 package spark;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.powermock.reflect.Whitebox;
-
 import spark.ssl.SslStores;
+
+import javax.servlet.http.HttpServletResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -237,6 +236,23 @@ public class ServiceTest {
         thrown.expect(NullPointerException.class);
         thrown.expectMessage("WebSocket handler class cannot be null");
         service.webSocket("/", null);
+    }
+
+    @Test
+    public void testMaxHeadersSize_whenInitializedFalse() throws Exception {
+        service.maxHeadersSize(1234);
+
+        final int maxHeadersSize = Whitebox.getInternalState(service, "maxHeadersSize");
+        assertEquals("MaxHeadersSize should be set to the value provided.", 1234, maxHeadersSize);
+    }
+
+    @Test
+    public void testMaxHeadersSize_whenInitializedTrue() throws Exception {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("This must be done before route mapping has begun");
+
+        Whitebox.setInternalState(service, "initialized", true);
+        service.maxHeadersSize(1234);
     }
     
     @WebSocket

--- a/src/test/java/spark/embeddedserver/jetty/SocketConnectorFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/SocketConnectorFactoryTest.java
@@ -20,7 +20,7 @@ public class SocketConnectorFactoryTest {
     public void testCreateSocketConnector_whenServerIsNull_thenThrowException() {
 
         try {
-            SocketConnectorFactory.createSocketConnector(null, "host", 80);
+            SocketConnectorFactory.createSocketConnector(null, "host", 80, 8192);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'server' must not be null", ex.getMessage());
@@ -34,7 +34,7 @@ public class SocketConnectorFactoryTest {
         Server server = new Server();
 
         try {
-            SocketConnectorFactory.createSocketConnector(server, null, 80);
+            SocketConnectorFactory.createSocketConnector(server, null, 80, 8192);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'host' must not be null", ex.getMessage());
@@ -48,7 +48,7 @@ public class SocketConnectorFactoryTest {
         final int port = 8888;
 
         Server server = new Server();
-        ServerConnector serverConnector = SocketConnectorFactory.createSocketConnector(server, "localhost", 8888);
+        ServerConnector serverConnector = SocketConnectorFactory.createSocketConnector(server, "localhost", 8888, 8192);
 
         String internalHost = Whitebox.getInternalState(serverConnector, "_host");
         int internalPort = Whitebox.getInternalState(serverConnector, "_port");
@@ -63,7 +63,7 @@ public class SocketConnectorFactoryTest {
     public void testCreateSecureSocketConnector_whenServerIsNull() {
 
         try {
-            SocketConnectorFactory.createSecureSocketConnector(null, "localhost", 80, null);
+            SocketConnectorFactory.createSecureSocketConnector(null, "localhost", 80, null, 8192);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'server' must not be null", ex.getMessage());
@@ -76,7 +76,7 @@ public class SocketConnectorFactoryTest {
         Server server = new Server();
 
         try {
-            SocketConnectorFactory.createSecureSocketConnector(server, null, 80, null);
+            SocketConnectorFactory.createSecureSocketConnector(server, null, 80, null, 8192);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'host' must not be null", ex.getMessage());
@@ -89,7 +89,7 @@ public class SocketConnectorFactoryTest {
         Server server = new Server();
 
         try {
-            SocketConnectorFactory.createSecureSocketConnector(server, "localhost", 80, null);
+            SocketConnectorFactory.createSecureSocketConnector(server, "localhost", 80, null, 8192);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'sslStores' must not be null", ex.getMessage());
@@ -113,7 +113,7 @@ public class SocketConnectorFactoryTest {
 
         Server server = new Server();
 
-        ServerConnector serverConnector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores);
+        ServerConnector serverConnector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores, 8192);
 
         String internalHost = Whitebox.getInternalState(serverConnector, "_host");
         int internalPort = Whitebox.getInternalState(serverConnector, "_port");


### PR DESCRIPTION
I've stumbled upon an issue that I've had to deal with client that is using huge headers (more than 16k) and Jetty's defaults were not good enough. This PR provides a Spark.maxHeadersSize(size) method that sets max headers size for both requests and responses.