### PR TITLE
Clear route on stop() properly

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -409,11 +409,11 @@ public final class Service extends Routable {
     public synchronized void stop() {
         new Thread(() -> {
             if (server != null) {
-                routes.clear();
                 server.extinguish();
                 latch = new CountDownLatch(1);
             }
-
+            
+            routes.clear();
             staticFilesConfiguration.clear();
             initialized = false;
         }).start();


### PR DESCRIPTION
When testing with `Spark`, it appeare that when we provide our webserver, not using jetty server emmbedded, `Spark`keep routes from a scenarii to another.

Now, i must done following thing in my unit test tear down method 😭  :

```
Class<?> sparkClass = Class.forName(Spark.class.getCanonicalName());
            Method method = sparkClass.getDeclaredMethod("getInstance");
            method.setAccessible(true);
            Object sparkService = method.invoke(sparkClass);

            //  Access to a protected field routes
            Class<?> sparkInstanceClass = Class.forName("spark.Service");
            Arrays.stream(sparkInstanceClass.getDeclaredFields())
                    .filter(f -> "routes".equals(f.getName()))
                    .findFirst()
                    .ifPresent(f -> {
                        // Access to the field routes and call clear() on it.
                        f.setAccessible(true);
                        try {
                            Routes routes  = (Routes) f.get(sparkService);
                            routes.clear();
                        } catch (IllegalAccessException e) {
                            e.printStackTrace();
                        }
                        LOGGER.info("Spark Routes cleared !!");
                    });

```
This very bad design workaround allow me to done a clean stop of Spark and relaunch it with other intance of routes.

My use case concern test case, but it put ahead an issue of `Spark`when stopping.

I'am open to any suggestion.

