### PR TITLE
Issue #829 - internalServerError should receive the exception

### DIFF
--- a/src/main/java/spark/CustomErrorPages.java
+++ b/src/main/java/spark/CustomErrorPages.java
@@ -67,6 +67,13 @@ public class CustomErrorPages {
              // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
                 LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
             }
+        } else if (customRenderer instanceof Route) {
+            try {
+                customPage = ((Route) customRenderer).handle(request, response);
+            } catch (Exception e) {
+                // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
+                LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
+            }
         }
 
         return customPage;

--- a/src/main/java/spark/CustomErrorPages.java
+++ b/src/main/java/spark/CustomErrorPages.java
@@ -49,7 +49,7 @@ public class CustomErrorPages {
      * @param status
      * @param request
      * @param response
- q     * @param exception
+     * @param exception
      * @return Object representing the custom error page
      */
     public static Object getFor(int status, Request request, Response response, Exception exception) {

--- a/src/main/java/spark/CustomErrorPages.java
+++ b/src/main/java/spark/CustomErrorPages.java
@@ -49,7 +49,7 @@ public class CustomErrorPages {
      * @param status
      * @param request
      * @param response
-     * @param exception
+ q     * @param exception
      * @return Object representing the custom error page
      */
     public static Object getFor(int status, Request request, Response response, Exception exception) {
@@ -64,7 +64,14 @@ public class CustomErrorPages {
             try {
                 customPage = ((ExceptionRoute) customRenderer).handle(exception, request, response);
             } catch (Exception e) {
-             // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
+                // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
+                LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
+            }
+        } else if (customRenderer instanceof Route) {
+            try {
+                customPage = ((Route) customRenderer).handle(request, response);
+            } catch (Exception e) {
+                // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
                 LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
             }
         } else if (customRenderer instanceof Route) {
@@ -89,7 +96,7 @@ public class CustomErrorPages {
         String defaultPage = defaultPages.get(status);
         return (defaultPage != null) ? defaultPage : "<html><body><h2>HTTP Status " + status + "</h2></body></html>";
     }
-    
+
     /**
      * Add a custom error page as a String
      * @param status

--- a/src/main/java/spark/CustomErrorPages.java
+++ b/src/main/java/spark/CustomErrorPages.java
@@ -49,18 +49,20 @@ public class CustomErrorPages {
      * @param status
      * @param request
      * @param response
+     * @param exception
      * @return Object representing the custom error page
      */
-    public static Object getFor(int status, Request request, Response response) {
+    public static Object getFor(int status, Request request, Response response, Exception exception) {
 
         Object customRenderer = CustomErrorPages.getInstance().customPages.get(status);
         Object customPage = CustomErrorPages.getInstance().getDefaultFor(status);
 
+
         if (customRenderer instanceof String) {
             customPage = customRenderer;
-        } else if (customRenderer instanceof Route) {
+        } else if (customRenderer instanceof ExceptionRoute) {
             try {
-                customPage = ((Route) customRenderer).handle(request, response);
+                customPage = ((ExceptionRoute) customRenderer).handle(exception, request, response);
             } catch (Exception e) {
              // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
                 LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
@@ -90,6 +92,14 @@ public class CustomErrorPages {
         CustomErrorPages.getInstance().customPages.put(status, page);
     }
 
+    /**
+     * Add a custom error page as a Route handler
+     * @param status
+     * @param route
+     */
+    static void add(int status, ExceptionRoute route) {
+        CustomErrorPages.getInstance().customPages.put(status, route);
+    }
     /**
      * Add a custom error page as a Route handler
      * @param status

--- a/src/main/java/spark/CustomErrorPages.java
+++ b/src/main/java/spark/CustomErrorPages.java
@@ -67,13 +67,13 @@ public class CustomErrorPages {
                 // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
                 LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
             }
-        } else if (customRenderer instanceof Route) {
+        } else if (customRenderer instanceof ExceptionRoute) {
             try {
-                customPage = ((Route) customRenderer).handle(request, response);
+                customPage = ((ExceptionRoute) customRenderer).handle(exception, request, response);
             } catch (Exception e) {
                 // The custom page renderer is causing an internal server error.  Log exception as a warning and use default page instead
-                LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
-            }
+               LOG.warn("Custom error page handler for status code {} has thrown an exception: {}. Using default page instead.", status, e.getMessage());
+           }
         } else if (customRenderer instanceof Route) {
             try {
                 customPage = ((Route) customRenderer).handle(request, response);

--- a/src/main/java/spark/ExceptionRoute.java
+++ b/src/main/java/spark/ExceptionRoute.java
@@ -1,0 +1,20 @@
+package spark;
+
+/**
+ * Created by Todd Sharp on 4/13/2017
+ */
+@FunctionalInterface
+public interface ExceptionRoute {
+
+    /**
+     * Invoked when a request is made on this route's corresponding path e.g. '/hello'
+     *
+     * @param exception The exception object (if one exists)
+     * @param request  The request object providing information about the HTTP request
+     * @param response The response object providing functionality for modifying the response
+     * @return The content to be set in the response
+     * @throws Exception implementation can choose to throw exception
+     */
+    Object handle(Exception exception, Request request, Response response) throws Exception;
+
+}

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -385,7 +385,7 @@ public final class Service extends Routable {
     /**
      * Maps 500 internal server errors to the provided route.
      */
-    public synchronized void internalServerError(Route route) {
+    public synchronized void internalServerError(ExceptionRoute route) {
         CustomErrorPages.add(500, route);
     }
 

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -390,6 +390,13 @@ public final class Service extends Routable {
     }
 
     /**
+     * Maps 500 internal server errors to the provided route.
+     */
+    public synchronized void internalServerError(Route route) {
+        CustomErrorPages.add(500, route);
+    }
+
+    /**
      * Waits for the spark server to be initialized.
      * If it's already initialized will return immediately
      */

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -1176,7 +1176,7 @@ public class Spark {
     /**
      * Maps 500 internal server errors to the provided route.
      */
-    public static void internalServerError(Route route) {
+    public static void internalServerError(ExceptionRoute route) {
         getInstance().internalServerError(route);
     }
 

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -1181,6 +1181,13 @@ public class Spark {
     }
 
     /**
+     * Maps 500 internal server errors to the provided route.
+     */
+    public static void internalServerError(Route route) {
+        getInstance().internalServerError(route);
+    }
+
+    /**
      * Initializes the Spark server. SHOULD just be used when using the Websockets functionality.
      */
     public static void init() {

--- a/src/main/java/spark/http/matching/GeneralError.java
+++ b/src/main/java/spark/http/matching/GeneralError.java
@@ -58,7 +58,7 @@ final class GeneralError {
             if (CustomErrorPages.existsFor(500)) {
                 requestWrapper.setDelegate(RequestResponseFactory.create(httpRequest));
                 responseWrapper.setDelegate(RequestResponseFactory.create(httpResponse));
-                body.set(CustomErrorPages.getFor(500, requestWrapper, responseWrapper));
+                body.set(CustomErrorPages.getFor(500, requestWrapper, responseWrapper, e));
             } else {
                 body.set(CustomErrorPages.INTERNAL_ERROR);
             }

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -166,7 +166,9 @@ public class MatcherFilter implements Filter {
                 if (CustomErrorPages.existsFor(404)) {
                     requestWrapper.setDelegate(RequestResponseFactory.create(httpRequest));
                     responseWrapper.setDelegate(RequestResponseFactory.create(httpResponse));
-                    body.set(CustomErrorPages.getFor(404, requestWrapper, responseWrapper));
+                    String message = "The requested route [" + uri + "] has not been mapped in Spark for " + ACCEPT_TYPE_REQUEST_MIME_HEADER + ": [" + acceptType + "]";
+                    Exception exception = new Exception(message);
+                    body.set(CustomErrorPages.getFor(404, requestWrapper, responseWrapper, exception));
                 } else {
                     body.set(String.format(CustomErrorPages.NOT_FOUND));
                 }

--- a/src/test/java/spark/customerrorpages/CustomErrorPagesTest.java
+++ b/src/test/java/spark/customerrorpages/CustomErrorPagesTest.java
@@ -42,7 +42,7 @@ public class CustomErrorPagesTest {
 
         notFound(CUSTOM_NOT_FOUND);
 
-        internalServerError((request, response) -> {
+        internalServerError((exception, request, response) -> {
             if (request.queryParams(QUERY_PARAM_KEY) != null) {
                 throw new Exception();
             }


### PR DESCRIPTION
Add a third argument to internalServerError to pass the exception.  All tests pass.  Note:  this will break existing applications as the third argument is now expected to exist in the closure/lambda function for this route.