### PR TITLE
Added ServletContext parameter to SparkApplication.init

### DIFF
--- a/src/main/java/spark/servlet/SparkApplication.java
+++ b/src/main/java/spark/servlet/SparkApplication.java
@@ -4,7 +4,7 @@
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 package spark.servlet;
+
+import javax.servlet.ServletContext;
 
 /**
  * The application entry point when Spark is run in a servlet context.
@@ -27,6 +29,13 @@ public interface SparkApplication {
      * Invoked from the SparkFilter. Add routes here.
      */
     void init();
+
+    /**
+     * Invoked from the SparkFilter. Default call to init()
+     */
+    default void init(ServletContext context) {
+        init();
+    };
 
     /**
      * Invoked from the SparkFilter.

--- a/src/main/java/spark/servlet/SparkFilter.java
+++ b/src/main/java/spark/servlet/SparkFilter.java
@@ -4,7 +4,7 @@
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -66,7 +66,7 @@ public class SparkFilter implements Filter {
         applications = getApplications(filterConfig);
 
         for (SparkApplication application : applications) {
-            application.init();
+            application.init(filterConfig.getServletContext());
         }
 
         filterPath = FilterTools.getFilterPath(filterConfig);
@@ -75,7 +75,7 @@ public class SparkFilter implements Filter {
     }
 
     /**
-     * Returns an instance of {@link SparkApplication} which on which {@link SparkApplication#init() init()} will be called.
+     * Returns an instance of {@link SparkApplication} on which {@link SparkApplication#init(javax.servlet.ServletContext) init(ServletContext)} will be called.
      * Default implementation looks up the class name in the filterConfig using the key {@value #APPLICATION_CLASS_PARAM}.
      * Subclasses can override this method to use different techniques to obtain an instance (i.e. dependency injection).
      *
@@ -90,7 +90,7 @@ public class SparkFilter implements Filter {
     }
 
     /**
-     * Returns an instance of {@link SparkApplication} which on which {@link SparkApplication#init() init()} will be called.
+     * Returns an instance of {@link SparkApplication} which on which {@link SparkApplication#init(javax.servlet.ServletContext) init(ServletContext)} will be called.
      * Default implementation looks up the class name in the filterConfig using the key {@value #APPLICATION_CLASS_PARAM}.
      * Subclasses can override this method to use different techniques to obtain an instance (i.e. dependency injection).
      *
@@ -108,7 +108,7 @@ public class SparkFilter implements Filter {
     }
 
     /**
-     * Returns the instances of {@link SparkApplication} which on which {@link SparkApplication#init() init()} will be called.
+     * Returns the instances of {@link SparkApplication} which on which {@link SparkApplication#init(javax.servlet.ServletContext) init(ServletContext)} will be called.
      * Default implementation looks up the class names in the filterConfig using the key {@value #APPLICATION_CLASS_PARAM}.
      * Subclasses can override this method to use different techniques to obtain an instance (i.e. dependency injection).
      *


### PR DESCRIPTION
This is a small change which doesn't break the filter API but allows its users to access to the servletcontext while initializing if they wish.