### PR TITLE
Add configurable path parameter matcher

### DIFF
--- a/src/main/java/spark/utils/SparkUtils.java
+++ b/src/main/java/spark/utils/SparkUtils.java
@@ -27,8 +27,27 @@ import java.util.List;
 public final class SparkUtils {
 
     public static final String ALL_PATHS = "+/*paths";
+    /**
+     * The default value for the path matcher and follows the standard convention.
+     * Path parameters can be defined as {@code :parameter}.
+     */
+    public static final String DEFAULT_PATTERN = ":.+";
+
+    /**
+     * Matcher for the curly bracket notation. This pattern is used by many
+     * popular frameworks like Spring MVC or OkHttp. The expression matches
+     * strings like {@code {id}, {value}} or {@code {pathVariable}}.
+     */
+    public static final String CURLY_BRACKET_MATCHER = "\\{.+\\}";
+
+    private static String regex = DEFAULT_PATTERN;
 
     private SparkUtils() {
+    }
+
+
+    public static void setParamPlaceholder(String regex) {
+        SparkUtils.regex = regex;
     }
 
     public static List<String> convertRouteToList(String route) {
@@ -43,7 +62,7 @@ public final class SparkUtils {
     }
 
     public static boolean isParam(String routePart) {
-        return routePart.startsWith(":");
+        return routePart.matches(regex);
     }
 
     public static boolean isSplat(String routePart) {

--- a/src/main/java/spark/utils/SparkUtils.java
+++ b/src/main/java/spark/utils/SparkUtils.java
@@ -46,7 +46,11 @@ public final class SparkUtils {
     }
 
 
-    public static void setParamPlaceholder(String regex) {
+    /**
+     * Set the regular expression for the path mather.
+     * @param regex regular expression for the path variables.
+     */
+    public static void paramMatcher(String regex) {
         SparkUtils.regex = regex;
     }
 

--- a/src/test/java/spark/utils/SparkUtilsTest.java
+++ b/src/test/java/spark/utils/SparkUtilsTest.java
@@ -11,16 +11,25 @@ import static org.junit.Assert.*;
 public class SparkUtilsTest {
 
     @Test
-    public void testConvertRouteToList() throws Exception {
-
+    public void testDefaultConvertRouteToList() throws Exception {
         List<String> expected = Arrays.asList("api", "person", ":id");
-
         List<String> actual = SparkUtils.convertRouteToList("/api/person/:id");
-
         assertThat("Should return route as a list of individual elements that path is made of",
                 actual,
                 is(expected));
 
+    }
+
+
+
+    @Test
+    public void testConvertRouteToList() throws Exception {
+        List<String> expected = Arrays.asList("api", "person", "{id}");
+        SparkUtils.setParamPlaceholder(SparkUtils.CURLY_BRACKET_MATCHER);
+        List<String> actual = SparkUtils.convertRouteToList("/api/person/{id}");
+        assertThat("Should return route as a list of individual elements that path is made of",
+            actual,
+            is(expected));
     }
 
     @Test

--- a/src/test/java/spark/utils/SparkUtilsTest.java
+++ b/src/test/java/spark/utils/SparkUtilsTest.java
@@ -25,7 +25,7 @@ public class SparkUtilsTest {
     @Test
     public void testConvertRouteToList() throws Exception {
         List<String> expected = Arrays.asList("api", "person", "{id}");
-        SparkUtils.setParamPlaceholder(SparkUtils.CURLY_BRACKET_MATCHER);
+        SparkUtils.paramMatcher(SparkUtils.CURLY_BRACKET_MATCHER);
         List<String> actual = SparkUtils.convertRouteToList("/api/person/{id}");
         assertThat("Should return route as a list of individual elements that path is made of",
             actual,


### PR DESCRIPTION
Now you can set the regular expression with `SparkUtils.paramMatcher(regex);`
There are two default values:
1) `DEFAULT_PATTERN` which matches the old style
2) `CURLY_BRACKET_MATCHER` which matches the curly bracket style used by Spring and OkHttp
3) You can also set your own pattern with the `paramMatcher(regex)` method.