### PR TITLE
Enable custom 404 pages for external web containers

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -532,6 +532,16 @@ public final class Service extends Routable {
         }
     }
 
+    /**
+     * @return The approximate number of currently active threads in the embedded Jetty server
+     */
+    public synchronized int activeThreadCount() {
+        if (server != null) {
+            return server.activeThreadCount();
+        }
+        return 0;
+    }
+
     //////////////////////////////////////////////////
     // EXCEPTION mapper
     //////////////////////////////////////////////////

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -1197,4 +1197,11 @@ public class Spark {
         return new ModelAndView(model, viewName);
     }
 
+    /**
+     * @return The approximate number of currently active threads in the embedded Jetty server
+     */
+    public static int activeThreadCount() {
+        return getInstance().activeThreadCount();
+    }
+
 }

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -158,7 +158,7 @@ public class MatcherFilter implements Filter {
                 }
             }
 
-            if (body.notSet() && !externalContainer) {
+            if (body.notSet()) {
                 LOG.info("The requested route [{}] has not been mapped in Spark for {}: [{}]",
                          uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);


### PR DESCRIPTION
Removed external container check. This gives external web containers the ability to use CustomErrorMessages.