### PR TITLE
Added activeThreadCount to Service and Spark classes

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -532,6 +532,16 @@ public final class Service extends Routable {
         }
     }
 
+    /**
+     * @return The approximate number of currently active threads in the embedded Jetty server
+     */
+    public synchronized int activeThreadCount() {
+        if (server != null) {
+            return server.activeThreadCount();
+        }
+        return 0;
+    }
+
     //////////////////////////////////////////////////
     // EXCEPTION mapper
     //////////////////////////////////////////////////

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -1197,4 +1197,11 @@ public class Spark {
         return new ModelAndView(model, viewName);
     }
 
+    /**
+     * @return The approximate number of currently active threads in the embedded Jetty server
+     */
+    public static int activeThreadCount() {
+        return getInstance().activeThreadCount();
+    }
+
 }


### PR DESCRIPTION
As mentioned in issue [885](https://github.com/perwendel/spark/issues/885), the activeThreadCount was not accessible through the Spark class.
Created a method in Service and Spark classes to make it accessible.