### PR TITLE
disable http request wrapper byte cache for multipart/form-data uploads

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/HttpRequestWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/HttpRequestWrapper.java
@@ -48,10 +48,21 @@ public class HttpRequestWrapper extends HttpServletRequestWrapper {
 
     @Override
     public ServletInputStream getInputStream() throws IOException {
-        String transferEncoding = ((HttpServletRequest) super.getRequest()).getHeader("Transfer-Encoding");
+        HttpServletRequest request = (HttpServletRequest) super.getRequest();
+
+        // disable stream cache for chunked transfer encoding
+        String transferEncoding = request.getHeader("Transfer-Encoding");
         if ("chunked".equals(transferEncoding)) {
-            return super.getInputStream(); // disable stream cache for chunked transfer encoding
+            return super.getInputStream();
         }
+
+        // disable stream cache for multipart/form-data file upload
+        // -> upload might be very large and might lead to out-of-memory error if we try to cache the bytes
+        String contentType = request.getHeader("Content-Type");
+        if (contentType != null && contentType.startsWith("multipart/form-data")) {
+            return super.getInputStream();
+        }
+
         if (cachedBytes == null) {
             cacheInputStream();
         }


### PR DESCRIPTION
large file uploads otherwise lead to out of memory error