### PR TITLE
Use `StaticFilesConfiguration` as the single source of truth.

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -65,9 +65,6 @@ public final class Service extends Routable {
 
     protected SslStores sslStores;
 
-    protected String staticFileFolder = null;
-    protected String externalStaticFileFolder = null;
-
     protected Map<String, WebSocketHandlerWrapper> webSocketHandlers = null;
 
     protected int maxThreads = -1;
@@ -78,9 +75,6 @@ public final class Service extends Routable {
     protected EmbeddedServer server;
     protected Deque<String> pathDeque = new ArrayDeque<>();
     protected Routes routes;
-
-    private boolean servletStaticLocationSet;
-    private boolean servletExternalStaticLocationSet;
 
     private CountDownLatch latch = new CountDownLatch(1);
 
@@ -266,12 +260,9 @@ public final class Service extends Routable {
         if (initialized && !isRunningFromServlet()) {
             throwBeforeRouteMappingException();
         }
-
-        staticFileFolder = folder;
-
-        if (!servletStaticLocationSet) {
-            staticFilesConfiguration.configure(staticFileFolder);
-            servletStaticLocationSet = true;
+        
+        if (!staticFilesConfiguration.isStaticResourcesSet()) {
+            staticFilesConfiguration.configure(folder);
         } else {
             LOG.warn("Static file location has already been set");
         }
@@ -289,12 +280,9 @@ public final class Service extends Routable {
         if (initialized && !isRunningFromServlet()) {
             throwBeforeRouteMappingException();
         }
-
-        externalStaticFileFolder = externalFolder;
-
-        if (!servletExternalStaticLocationSet) {
-            staticFilesConfiguration.configureExternal(externalStaticFileFolder);
-            servletExternalStaticLocationSet = true;
+        
+        if (!staticFilesConfiguration.isExternalStaticResourcesSet()) {
+            staticFilesConfiguration.configureExternal(externalFolder);
         } else {
             LOG.warn("External static file location has already been set");
         }

--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -123,6 +123,14 @@ public class StaticFilesConfiguration {
         staticResourcesSet = false;
         externalStaticResourcesSet = false;
     }
+    
+    public boolean isStaticResourcesSet() {
+        return staticResourcesSet;
+    }
+    
+    public boolean isExternalStaticResourcesSet() {
+        return externalStaticResourcesSet;
+    }
 
     /**
      * Configures location for static resources
@@ -143,7 +151,6 @@ public class StaticFilesConfiguration {
             StaticFilesFolder.localConfiguredTo(folder);
             staticResourcesSet = true;
         }
-
     }
 
     /**
@@ -174,7 +181,6 @@ public class StaticFilesConfiguration {
             StaticFilesFolder.externalConfiguredTo(folder);
             externalStaticResourcesSet = true;
         }
-
     }
 
     public static StaticFilesConfiguration create() {


### PR DESCRIPTION
Ditch local variables in `Service` in favour of consulting
the configuration object. Also fixes the issue of not properly
clearing on stop.