### PR TITLE
fix charset not work

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -74,7 +74,6 @@ public class MatcherFilter implements Filter {
         this.staticFiles = staticFiles;
         this.externalContainer = externalContainer;
         this.hasOtherHandlers = hasOtherHandlers;
-        this.serializerChain = new SerializerChain();
     }
 
     @Override
@@ -186,6 +185,7 @@ public class MatcherFilter implements Filter {
         }
 
         if (body.isSet()) {
+            serializerChain = new SerializerChain(httpResponse.getCharacterEncoding());
             body.serializeTo(httpResponse, serializerChain, httpRequest);
         } else if (chain != null) {
             chain.doFilter(httpRequest, httpResponse);

--- a/src/main/java/spark/serialization/DefaultSerializer.java
+++ b/src/main/java/spark/serialization/DefaultSerializer.java
@@ -27,6 +27,17 @@ import java.io.UnsupportedEncodingException;
  */
 class DefaultSerializer extends Serializer {
 
+    private String encoding = "utf-8";
+
+    public DefaultSerializer() {
+        super();
+    }
+
+    public DefaultSerializer(String encoding) {
+        super();
+        this.encoding = encoding;
+    }
+
     @Override
     public boolean canProcess(Object element) {
         return true;
@@ -35,7 +46,7 @@ class DefaultSerializer extends Serializer {
     @Override
     public void process(OutputStream outputStream, Object element) throws IOException {
         try {
-            outputStream.write(element.toString().getBytes("utf-8"));
+            outputStream.write(element.toString().getBytes(this.encoding));
         } catch (UnsupportedEncodingException e) {
             throw new IOException(e);
         }

--- a/src/main/java/spark/serialization/SerializerChain.java
+++ b/src/main/java/spark/serialization/SerializerChain.java
@@ -29,9 +29,9 @@ public final class SerializerChain {
     /**
      * Constructs a serializer chain.
      */
-    public SerializerChain() {
+    public SerializerChain(String encoding) {
 
-        DefaultSerializer defaultSerializer = new DefaultSerializer();
+        DefaultSerializer defaultSerializer = new DefaultSerializer(encoding);
 
         InputStreamSerializer inputStreamSerializer = new InputStreamSerializer();
         inputStreamSerializer.setNext(defaultSerializer);


### PR DESCRIPTION
#906 
give `DefaultSerializer` a argument to set encoding used to serialize.
when serializing body, use encoding from `httpResponse.getCharacterEncoding()`