### PR TITLE
Enable custom 404 pages for external web container

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -158,7 +158,7 @@ public class MatcherFilter implements Filter {
                 }
             }
 
-            if (body.notSet() && !externalContainer) {
+            if (body.notSet()) {
                 LOG.info("The requested route [{}] has not been mapped in Spark for {}: [{}]",
                          uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);


### PR DESCRIPTION
This change makes it possible for external web containers to serve up the configured (or default) 404 response.