### PR TITLE
Updating EmbeddedJettyServer to work with custom connectors 

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -101,8 +101,27 @@ public class EmbeddedJettyServer implements EmbeddedServer {
             connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores);
         }
 
+        Connector previousConnectors[] = server.getConnectors();
+        logger.info("Previous Server Connectors: {}", previousConnectors.toString());
         server = connector.getServer();
-        server.setConnectors(new Connector[] {connector});
+        if (previousConnectors.length != 0) {
+            logger.info("Previous Connectors vector has size: {}", previousConnectors.length);
+            Connector connectorsVector[] = new Connector[previousConnectors.length+1];
+            logger.info("Created Connectors vector with size: {}", previousConnectors.length+1);
+            for (int i=0; i<connectorsVector.length; i++) {
+                logger.info("Adding Connector: {}", i+1);
+                if (i!=(connectorsVector.length-1))
+                    connectorsVector[i]=previousConnectors[i];
+                else
+                    connectorsVector[i]=(Connector)connector;
+            }
+            server.setConnectors(previousConnectors);
+            logger.info("New Connectors vector successfuly set!");
+        } else {
+            logger.info("No Previous Connectors vector!");
+            server.setConnectors(new Connector[] {connector});
+            logger.info("Standard Connectors vector successfuly set!");
+        }
 
         ServletContextHandler webSocketServletContextHandler =
             WebSocketServletContextHandlerFactory.create(webSocketHandlers, webSocketIdleTimeoutMillis);

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -81,6 +81,7 @@ public class EmbeddedJettyServer implements EmbeddedServer {
                       int minThreads,
                       int threadIdleTimeoutMillis) throws Exception {
 
+        boolean hasCustomizedConnectors = false;
 
         if (port == 0) {
             try (ServerSocket s = new ServerSocket(0)) {
@@ -102,25 +103,12 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         }
 
         Connector previousConnectors[] = server.getConnectors();
-        logger.info("Previous Server Connectors: {}", previousConnectors.toString());
         server = connector.getServer();
         if (previousConnectors.length != 0) {
-            logger.info("Previous Connectors vector has size: {}", previousConnectors.length);
-            Connector connectorsVector[] = new Connector[previousConnectors.length+1];
-            logger.info("Created Connectors vector with size: {}", previousConnectors.length+1);
-            for (int i=0; i<connectorsVector.length; i++) {
-                logger.info("Adding Connector: {}", i+1);
-                if (i!=(connectorsVector.length-1))
-                    connectorsVector[i]=previousConnectors[i];
-                else
-                    connectorsVector[i]=(Connector)connector;
-            }
             server.setConnectors(previousConnectors);
-            logger.info("New Connectors vector successfuly set!");
+            hasCustomizedConnectors = true;
         } else {
-            logger.info("No Previous Connectors vector!");
             server.setConnectors(new Connector[] {connector});
-            logger.info("Standard Connectors vector successfuly set!");
         }
 
         ServletContextHandler webSocketServletContextHandler =
@@ -144,7 +132,11 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         }
 
         logger.info("== {} has ignited ...", NAME);
-        logger.info(">> Listening on {}:{}", host, port);
+        if (hasCustomizedConnectors) {
+            logger.info(">> Listening on Custom Server ports!");
+        } else {
+            logger.info(">> Listening on {}:{}", host, port);
+        }
 
         server.start();
         return port;

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -88,6 +88,8 @@ public class SocketConnectorFactory {
             sslContextFactory.setWantClientAuth(true);
         }
 
+        sslContextFactory.setIncludeProtocols("TLSv1","TLSv1.1","TLSv1.2" );
+
         HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
 
         ServerConnector connector = new ServerConnector(server, sslContextFactory, httpConnectionFactory);

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -88,7 +88,8 @@ public class SocketConnectorFactory {
             sslContextFactory.setWantClientAuth(true);
         }
 
-        sslContextFactory.setIncludeProtocols("TLSv1","TLSv1.1","TLSv1.2" );
+        // Temporary solution to works with IBM JVM
+        //sslContextFactory.setIncludeProtocols("TLSv1","TLSv1.1","TLSv1.2" );
 
         HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
 

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -88,9 +88,6 @@ public class SocketConnectorFactory {
             sslContextFactory.setWantClientAuth(true);
         }
 
-        // Temporary solution to works with IBM JVM
-        //sslContextFactory.setIncludeProtocols("TLSv1","TLSv1.1","TLSv1.2" );
-
         HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
 
         ServerConnector connector = new ServerConnector(server, sslContextFactory, httpConnectionFactory);


### PR DESCRIPTION
- To overcome Java IBM issues (handshake_failure) when deploying Spark
  applications, the enabled protocols are now explicitly declared and set
  on sslContextFactory during the creation of a Secure Socket Connector.

- This pull-request refers to Issue #914 