### PR TITLE
#932. User gets 404 after exception handling

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -158,7 +158,7 @@ public class MatcherFilter implements Filter {
                 }
             }
 
-            if (body.notSet()) {
+            if (body.notSet() && !context.isMatched()) {
                 LOG.info("The requested route [{}] has not been mapped in Spark for {}: [{}]",
                          uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);

--- a/src/main/java/spark/http/matching/RouteContext.java
+++ b/src/main/java/spark/http/matching/RouteContext.java
@@ -43,6 +43,7 @@ final class RouteContext {
     private ResponseWrapper responseWrapper;
     private Response response;
     private HttpMethod httpMethod;
+    private boolean matched;
 
     private RouteContext() {
         // hidden
@@ -129,4 +130,11 @@ final class RouteContext {
         return httpMethod;
     }
 
+    public boolean isMatched() {
+        return matched;
+    }
+
+    public void setMatched(boolean matched) {
+        this.matched = matched;
+    }
 }

--- a/src/main/java/spark/http/matching/Routes.java
+++ b/src/main/java/spark/http/matching/Routes.java
@@ -55,7 +55,7 @@ final class Routes {
                 } else {
                     context.requestWrapper().changeMatch(match);
                 }
-
+                context.setMatched(true);
                 context.responseWrapper().setDelegate(context.response());
 
                 Object element = route.handle(context.requestWrapper(), context.responseWrapper());

--- a/src/test/java/spark/MatcherFilterTest.java
+++ b/src/test/java/spark/MatcherFilterTest.java
@@ -1,0 +1,69 @@
+package spark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil;
+
+import java.io.IOException;
+
+import static spark.Spark.awaitInitialization;
+import static spark.Spark.get;
+import static spark.Spark.before;
+import static spark.Spark.exception;
+import static spark.Spark.stop;
+
+public class MatcherFilterTest {
+    static SparkTestUtil testUtil;
+
+    @AfterClass
+    public static void tearDown() {
+        stop();
+    }
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        testUtil = new SparkTestUtil(4567);
+
+        get("/juststatus", (q, a) -> {
+            a.status(204);
+            return null;
+        });
+
+        get("/justerror", (q, a) -> {
+            throw new Exception("Failed method");
+        });
+
+        before("/justerrorfilter", (q, a) -> {
+            throw new Exception("Failed filter");
+        });
+
+        exception(Exception.class, (exception, request, response) -> {
+            response.status(400);
+        });
+
+        awaitInitialization();
+    }
+
+    @Test
+    public void testJustStatus() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/juststatus", null);
+
+        Assert.assertEquals(204, response.status);
+    }
+
+    @Test
+    public void testException() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/justerror", null);
+
+        Assert.assertEquals(400, response.status);
+    }
+
+    @Test
+    public void testJustFilterException() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/justerrorfilter", null);
+
+        Assert.assertEquals(404, response.status);
+    }
+}


### PR DESCRIPTION
Sometimes we need to set only status code (as example for HTTP 204) without returning an empty string.
it's surprise for beginners and me too:) that this code doesn't work as expected
`
Spark.head("/api/resource/check", (req, res) -> {
            res.status(HttpStatus.NO_CONTENT_204);
            return null;
 });
`
