### PR TITLE
Replaced explicit null-checks by a declarative approach

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,19 @@
             <version>${jetty.version}</version>
         </dependency>
 
+        <!-- NULL-CHECK DEPENDENCIES -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>tech.harmonysoft</groupId>
+            <artifactId>traute-javac</artifactId>
+            <version>1.0.10</version>
+            <scope>provided</scope><!-- make the jar eligible for compilation only -->
+        </dependency>
+
         <!-- JUNIT DEPENDENCY FOR TESTING -->
         <dependency>
             <groupId>junit</groupId>
@@ -161,6 +174,11 @@
                     <target>${java.version}</target>
                     <optimize>true</optimize>
                     <debug>true</debug>
+                    <compilerArgs>
+                        <arg>-Xplugin:Traute</arg>
+                        <arg>-Atraute.exception.parameter=IllegalArgumentException</arg>
+                        <arg>-Atraute.failure.text.parameter='$${PARAMETER_NAME}' must not be null</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -40,7 +40,8 @@ import spark.ssl.SslStores;
 import spark.staticfiles.MimeType;
 import spark.staticfiles.StaticFilesConfiguration;
 
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nonnull;
+
 import static spark.globalstate.ServletFlag.isRunningFromServlet;
 
 /**
@@ -313,14 +314,13 @@ public final class Service extends Routable {
         addWebSocketHandler(path, new WebSocketHandlerInstanceWrapper(handler));
     }
 
-    private synchronized void addWebSocketHandler(String path, WebSocketHandlerWrapper handlerWrapper) {
+    private synchronized void addWebSocketHandler(@Nonnull String path, WebSocketHandlerWrapper handlerWrapper) {
         if (initialized) {
             throwBeforeRouteMappingException();
         }
         if (isRunningFromServlet()) {
             throw new IllegalStateException("WebSockets are only supported in the embedded server");
         }
-        requireNonNull(path, "WebSocket path cannot be null");
         if (webSocketHandlers == null) {
             webSocketHandlers = new HashMap<>();
         }

--- a/src/main/java/spark/Session.java
+++ b/src/main/java/spark/Session.java
@@ -4,9 +4,8 @@ import java.util.Enumeration;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpSession;
-
-import spark.utils.Assert;
 
 /**
  * Provides session information.
@@ -23,9 +22,7 @@ public class Session {
      * @param request
      * @throws IllegalArgumentException If the session or the request is null.
      */
-    Session(HttpSession session, Request request) {
-        Assert.notNull(session, "session cannot be null");
-        Assert.notNull(request, "request cannot be null");
+    Session(@Nonnull HttpSession session, @Nonnull Request request) {
         this.session = session;
         this.request = request;
     }

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -26,7 +26,8 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import spark.ssl.SslStores;
-import spark.utils.Assert;
+
+import javax.annotation.Nonnull;
 
 /**
  * Creates socket connectors.
@@ -41,9 +42,7 @@ public class SocketConnectorFactory {
      * @param port   port
      * @return - a server jetty
      */
-    public static ServerConnector createSocketConnector(Server server, String host, int port) {
-        Assert.notNull(server, "'server' must not be null");
-        Assert.notNull(host, "'host' must not be null");
+    public static ServerConnector createSocketConnector(@Nonnull Server server, @Nonnull String host, int port) {
 
         HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
         ServerConnector connector = new ServerConnector(server, httpConnectionFactory);
@@ -61,14 +60,10 @@ public class SocketConnectorFactory {
      * @param port      port
      * @return a ssl socket jetty
      */
-    public static ServerConnector createSecureSocketConnector(Server server,
-                                                              String host,
+    public static ServerConnector createSecureSocketConnector(@Nonnull Server server,
+                                                              @Nonnull String host,
                                                               int port,
-                                                              SslStores sslStores) {
-        Assert.notNull(server, "'server' must not be null");
-        Assert.notNull(host, "'host' must not be null");
-        Assert.notNull(sslStores, "'sslStores' must not be null");
-
+                                                              @Nonnull SslStores sslStores) {
         SslContextFactory sslContextFactory = new SslContextFactory(sslStores.keystoreFile());
 
         if (sslStores.keystorePassword() != null) {

--- a/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketCreatorFactory.java
@@ -19,7 +19,7 @@ import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nonnull;
 
 /**
  * Factory class to create {@link WebSocketCreator} implementations that
@@ -44,8 +44,8 @@ public class WebSocketCreatorFactory {
     static class SparkWebSocketCreator implements WebSocketCreator {
         private final Object handler;
 
-        private SparkWebSocketCreator(Object handler) {
-            this.handler = requireNonNull(handler, "handler cannot be null");
+        private SparkWebSocketCreator(@Nonnull Object handler) {
+            this.handler = handler;
         }
 
         @Override

--- a/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketHandlerClassWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketHandlerClassWrapper.java
@@ -1,13 +1,12 @@
 package spark.embeddedserver.jetty.websocket;
 
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nonnull;
 
 public class WebSocketHandlerClassWrapper implements WebSocketHandlerWrapper {
     
     private final Class<?> handlerClass;
 
-    public WebSocketHandlerClassWrapper(Class<?> handlerClass) {
-        requireNonNull(handlerClass, "WebSocket handler class cannot be null");
+    public WebSocketHandlerClassWrapper(@Nonnull Class<?> handlerClass) {
         WebSocketHandlerWrapper.validateHandlerClass(handlerClass);
         this.handlerClass = handlerClass;
     }

--- a/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketHandlerInstanceWrapper.java
+++ b/src/main/java/spark/embeddedserver/jetty/websocket/WebSocketHandlerInstanceWrapper.java
@@ -1,13 +1,12 @@
 package spark.embeddedserver.jetty.websocket;
 
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nonnull;
 
 public class WebSocketHandlerInstanceWrapper implements WebSocketHandlerWrapper {
     
     private final Object handler;
     
-    public WebSocketHandlerInstanceWrapper(Object handler) {
-        requireNonNull(handler, "WebSocket handler cannot be null");
+    public WebSocketHandlerInstanceWrapper(@Nonnull Object handler) {
         WebSocketHandlerWrapper.validateHandlerClass(handler.getClass());
         this.handler = handler;
     }

--- a/src/main/java/spark/resource/ClassPathResource.java
+++ b/src/main/java/spark/resource/ClassPathResource.java
@@ -16,14 +16,14 @@
 
 package spark.resource;
 
+import spark.utils.ClassUtils;
+import spark.utils.StringUtils;
+
+import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-
-import spark.utils.Assert;
-import spark.utils.ClassUtils;
-import spark.utils.StringUtils;
 
 /**
  * {@link Resource} implementation for class path resources.
@@ -72,8 +72,7 @@ public class ClassPathResource extends AbstractFileResolvingResource {
      *                    or {@code null} for the thread context class loader
      * @see ClassLoader#getResourceAsStream(String)
      */
-    public ClassPathResource(String path, ClassLoader classLoader) {
-        Assert.notNull(path, "Path must not be null");
+    public ClassPathResource(@Nonnull String path, ClassLoader classLoader) {
         String pathToUse = StringUtils.cleanPath(path);
         if (pathToUse.startsWith("/")) {
             pathToUse = pathToUse.substring(1);

--- a/src/main/java/spark/resource/ClassPathResourceHandler.java
+++ b/src/main/java/spark/resource/ClassPathResourceHandler.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import spark.staticfiles.DirectoryTraversal;
 import spark.utils.Assert;
 
+import javax.annotation.Nonnull;
+
 /**
  * Locates resources in classpath
  * Code snippets copied from Eclipse Jetty source. Modifications made by Per Wendel.
@@ -50,9 +52,7 @@ public class ClassPathResourceHandler extends AbstractResourceHandler {
      * @param baseResource the base resource path
      * @param welcomeFile  the welcomeFile
      */
-    public ClassPathResourceHandler(String baseResource, String welcomeFile) {
-        Assert.notNull(baseResource);
-
+    public ClassPathResourceHandler(@Nonnull String baseResource, String welcomeFile) {
         this.baseResource = baseResource;
         this.welcomeFile = welcomeFile;
     }

--- a/src/main/java/spark/resource/ExternalResourceHandler.java
+++ b/src/main/java/spark/resource/ExternalResourceHandler.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import spark.staticfiles.DirectoryTraversal;
 import spark.utils.Assert;
 
+import javax.annotation.Nonnull;
+
 /**
  * Locates resources from external folder
  * Code snippets copied from Eclipse Jetty source. Modifications made by Per Wendel.
@@ -50,8 +52,7 @@ public class ExternalResourceHandler extends AbstractResourceHandler {
      * @param baseResource the base resource path
      * @param welcomeFile  the welcomeFile
      */
-    public ExternalResourceHandler(String baseResource, String welcomeFile) {
-        Assert.notNull(baseResource);
+    public ExternalResourceHandler(@Nonnull String baseResource, String welcomeFile) {
         this.baseResource = baseResource;
         this.welcomeFile = welcomeFile;
     }

--- a/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
+++ b/src/main/java/spark/staticfiles/StaticFilesConfiguration.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -36,7 +37,6 @@ import spark.resource.AbstractResourceHandler;
 import spark.resource.ClassPathResourceHandler;
 import spark.resource.ExternalResource;
 import spark.resource.ExternalResourceHandler;
-import spark.utils.Assert;
 import spark.utils.GzipUtils;
 import spark.utils.IOUtils;
 
@@ -137,9 +137,7 @@ public class StaticFilesConfiguration {
      *
      * @param folder the location
      */
-    public synchronized void configure(String folder) {
-        Assert.notNull(folder, "'folder' must not be null");
-
+    public synchronized void configure(@Nonnull String folder) {
         if (!staticResourcesSet) {
 
             if (staticResourceHandlers == null) {
@@ -158,9 +156,7 @@ public class StaticFilesConfiguration {
      *
      * @param folder the location
      */
-    public synchronized void configureExternal(String folder) {
-        Assert.notNull(folder, "'folder' must not be null");
-
+    public synchronized void configureExternal(@Nonnull String folder) {
         if (!externalStaticResourcesSet) {
             try {
                 ExternalResource resource = new ExternalResource(folder);

--- a/src/main/java/spark/utils/Assert.java
+++ b/src/main/java/spark/utils/Assert.java
@@ -55,31 +55,6 @@ public abstract class Assert {
     }
 
     /**
-     * Assert that an object is not {@code null} .
-     * <pre class="code">Assert.notNull(clazz, "The class must not be null");</pre>
-     *
-     * @param object  the object to check
-     * @param message the exception message to use if the assertion fails
-     * @throws IllegalArgumentException if the object is {@code null}
-     */
-    public static void notNull(Object object, String message) {
-        if (object == null) {
-            throw new IllegalArgumentException(message);
-        }
-    }
-
-    /**
-     * Assert that an object is not {@code null} .
-     * <pre class="code">Assert.notNull(clazz);</pre>
-     *
-     * @param object the object to check
-     * @throws IllegalArgumentException if the object is {@code null}
-     */
-    public static void notNull(Object object) {
-        notNull(object, "[Assertion failed] - this argument is required; it must not be null");
-    }
-
-    /**
      * Assert that the given String is not empty; that is,
      * it must not be {@code null} and not the empty String.
      * <pre class="code">Assert.hasLength(name, "Name must not be empty");</pre>

--- a/src/main/java/spark/utils/ClassUtils.java
+++ b/src/main/java/spark/utils/ClassUtils.java
@@ -15,6 +15,7 @@
  */
 package spark.utils;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -161,8 +162,8 @@ public abstract class ClassUtils {
      * @throws LinkageError           if the class file could not be loaded
      * @see Class#forName(String, boolean, ClassLoader)
      */
-    public static Class<?> forName(String name, ClassLoader classLoader) throws ClassNotFoundException, LinkageError {
-        Assert.notNull(name, "Name must not be null");
+    public static Class<?> forName(@Nonnull String name, ClassLoader classLoader)
+        throws ClassNotFoundException, LinkageError {
 
         Class<?> clazz = resolvePrimitiveClassName(name);
         if (clazz == null) {

--- a/src/main/java/spark/utils/ResourceUtils.java
+++ b/src/main/java/spark/utils/ResourceUtils.java
@@ -16,6 +16,7 @@
 
 package spark.utils;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
@@ -122,8 +123,7 @@ public abstract class ResourceUtils {
      * @return a corresponding URL object
      * @throws FileNotFoundException if the resource cannot be resolved to a URL
      */
-    public static URL getURL(String resourceLocation) throws FileNotFoundException {
-        Assert.notNull(resourceLocation, "Resource location must not be null");
+    public static URL getURL(@Nonnull String resourceLocation) throws FileNotFoundException {
         if (resourceLocation.startsWith(CLASSPATH_URL_PREFIX)) {
             String path = resourceLocation.substring(CLASSPATH_URL_PREFIX.length());
             URL url = ClassUtils.getDefaultClassLoader().getResource(path);
@@ -160,8 +160,7 @@ public abstract class ResourceUtils {
      * @throws FileNotFoundException if the resource cannot be resolved to
      *                               a file in the file system
      */
-    public static File getFile(String resourceLocation) throws FileNotFoundException {
-        Assert.notNull(resourceLocation, "Resource location must not be null");
+    public static File getFile(@Nonnull String resourceLocation) throws FileNotFoundException {
         if (resourceLocation.startsWith(CLASSPATH_URL_PREFIX)) {
             String path = resourceLocation.substring(CLASSPATH_URL_PREFIX.length());
             String description = "class path resource [" + path + "]";
@@ -207,8 +206,7 @@ public abstract class ResourceUtils {
      * @throws FileNotFoundException if the URL cannot be resolved to
      *                               a file in the file system
      */
-    public static File getFile(URL resourceUrl, String description) throws FileNotFoundException {
-        Assert.notNull(resourceUrl, "Resource URL must not be null");
+    public static File getFile(@Nonnull URL resourceUrl, String description) throws FileNotFoundException {
         if (!URL_PROTOCOL_FILE.equals(resourceUrl.getProtocol())) {
             throw new FileNotFoundException(
                     description + " cannot be resolved to absolute file path " +
@@ -247,8 +245,7 @@ public abstract class ResourceUtils {
      * @throws FileNotFoundException if the URL cannot be resolved to
      *                               a file in the file system
      */
-    public static File getFile(URI resourceUri, String description) throws FileNotFoundException {
-        Assert.notNull(resourceUri, "Resource URI must not be null");
+    public static File getFile(@Nonnull URI resourceUri, String description) throws FileNotFoundException {
         if (!URL_PROTOCOL_FILE.equals(resourceUri.getScheme())) {
             throw new FileNotFoundException(
                     description + " cannot be resolved to absolute file path " +

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -227,15 +227,15 @@ public class ServiceTest {
     
     @Test
     public void testWebSocket_whenPathNull_thenThrowNullPointerException() {
-        thrown.expect(NullPointerException.class);
-        thrown.expectMessage("WebSocket path cannot be null");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("'path' must not be null");
         service.webSocket(null, new DummyWebSocketListener());
     }
     
     @Test
     public void testWebSocket_whenHandlerNull_thenThrowNullPointerException() {
-        thrown.expect(NullPointerException.class);
-        thrown.expectMessage("WebSocket handler class cannot be null");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("'handlerClass' must not be null");
         service.webSocket("/", null);
     }
     

--- a/src/test/java/spark/SessionTest.java
+++ b/src/test/java/spark/SessionTest.java
@@ -38,7 +38,7 @@ public class SessionTest {
 
         } catch (IllegalArgumentException ex) {
 
-            assertEquals("session cannot be null", ex.getMessage());
+            assertEquals("'session' must not be null", ex.getMessage());
         }
     }
 
@@ -52,7 +52,7 @@ public class SessionTest {
 
         } catch (IllegalArgumentException ex) {
 
-            assertEquals("request cannot be null", ex.getMessage());
+            assertEquals("'request' must not be null", ex.getMessage());
         }
     }
 


### PR DESCRIPTION
The idea is to do the following:  
1. Remove explicit *null*-checks
2. Mark corresponding method parameters by *Nonnull* annotation
3. Configure the project to use [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin to enhance resulting bytecode by *null*-checks for the target method parameters  

Example: consider [ClassPathResource](https://github.com/denis-zhdanov/spark/commit/b9159ecbf8e45b2740d937ae7fbf5e5222cb25bf#diff-30e3cccc077c04f39eb783f91945edd7):  

**Before**  

```java
public ClassPathResource(String path, ClassLoader classLoader) {
    Assert.notNull(path, "Path must not be null");
    String pathToUse = StringUtils.cleanPath(path);
    ....
```  

**After**  

```java
public ClassPathResource(@Nonnull String path, ClassLoader classLoader) {
    String pathToUse = StringUtils.cleanPath(path);
    ....
```  

Resulting bytecode:  

```
javap -c ./target/classes/spark/resource/ClassPathResource.class
...
  public spark.resource.ClassPathResource(java.lang.String, java.lang.ClassLoader);
    Code:
       0: aload_0
       1: invokespecial #2                  // Method spark/resource/AbstractFileResolvingResource."<init>":()V
       4: aload_1
       5: ifnonnull     18
       8: new           #3                  // class java/lang/IllegalArgumentException
      11: dup
      12: ldc           #4                  // String 'path' must not be null
      14: invokespecial #5                  // Method java/lang/IllegalArgumentException."<init>":(Ljava/lang/String;)V
      17: athrow
```  

Benefits:  
* the code is cleaner because explicit *null*-checks are removed
* the code is better documented because it clearly indicates which parameters can't be *null*
* IDEs highlight possible *NPE* problems for method parameters marked by *Nonnull*

TESTED: mvn clean package & ensured
        that resulting bytecode contains null-checks