### PR TITLE
Add methods to set long and date headers

### DIFF
--- a/src/main/java/spark/Response.java
+++ b/src/main/java/spark/Response.java
@@ -16,13 +16,14 @@
  */
 package spark;
 
-import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
 
 /**
  * Provides functionality for modifying the response
@@ -153,6 +154,46 @@ public class Response {
      */
     public void header(String header, String value) {
         response.addHeader(header, value);
+    }
+
+    /**
+     * Adds/Sets a response header
+     *
+     * @param header the header
+     * @param value  the value
+     */
+    public void header(String header, int value) {
+        response.addIntHeader(header, value);
+    }
+
+    /**
+     * Adds/Sets a response header
+     *
+     * @param header the header
+     * @param value  the value
+     */
+    public void header(String header, Date value) {
+        response.addDateHeader(header, value.getTime());
+    }
+
+    /**
+     * Adds/Sets a response header
+     *
+     * @param header the header
+     * @param value  the value
+     */
+    public void header(String header, java.sql.Date value) {
+        response.addDateHeader(header, value.getTime());
+    }
+
+    /**
+     * Adds/Sets a response header
+     *
+     * @param header the header
+     * @param value  the value
+     */
+    public void header(String header, Instant value) {
+        response.addDateHeader(header, value.toEpochMilli());
     }
 
     /**

--- a/src/test/java/spark/ResponseTest.java
+++ b/src/test/java/spark/ResponseTest.java
@@ -7,6 +7,7 @@ import org.powermock.reflect.Whitebox;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -91,6 +92,33 @@ public class ResponseTest {
 
         response.header(finalHeaderKey, finalHeaderValue);
         verify(httpServletResponse).addHeader(finalHeaderKey, finalHeaderValue);
+    }
+
+    @Test
+    public void testIntHeader() {
+        response.header("X-Processing-Time", 10);
+        verify(httpServletResponse).addIntHeader("X-Processing-Time", 10);
+    }
+
+    @Test
+    public void testJavaUtilDateHeader() {
+        Date now = new Date();
+        response.header("X-Processing-Since", now);
+        verify(httpServletResponse).addDateHeader("X-Processing-Since", now.getTime());
+    }
+
+    @Test
+    public void testJavaSqlDateHeader() {
+        Date now = new Date();
+        response.header("X-Processing-Since", new java.sql.Date(now.getTime()));
+        verify(httpServletResponse).addDateHeader("X-Processing-Since", now.getTime());
+    }
+
+    @Test
+    public void testInstantDateHeader() {
+        Date now = new Date();
+        response.header("X-Processing-Since", now.toInstant());
+        verify(httpServletResponse).addDateHeader("X-Processing-Since", now.getTime());
     }
 
     private void validateCookieContent(Cookie cookie,


### PR DESCRIPTION
Useful for setting headers like `Expires` and `Last-Modified` that are
expected to contain timestamps.