### PR TITLE
Set HttpOnly for session cookie due to improvement of security.

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
@@ -43,6 +43,7 @@ public class EmbeddedJettyFactory implements EmbeddedServerFactory {
         matcherFilter.init(null);
 
         JettyHandler handler = new JettyHandler(matcherFilter);
+		handler.getSessionCookieConfig().setHttpOnly(true);
         return new EmbeddedJettyServer(serverFactory, handler).withThreadPool(threadPool);
     }
 


### PR DESCRIPTION
Cookies are usually created by a server, passed to the browser and then passed back. Now it is possible to create and manipulate Cookies using JavaScript which can be helpful but can also be a security hole. So an HttpOnly Cookie is only accessible by the server, or in other words it is not accessible from client side JavaScript which protects your site from some forms of XSS attacks. So the Browser will store and return an HttpOnly Cookie but it will not alter it or allow you to create it on the client; an HttpOnly Cookie must be created on the server.
Overall, for security improvement cookies must be HttpOnly.