### PR TITLE
Ensure InputStreams returned by Routes are closed

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -16,6 +16,7 @@
  */
 package spark.http.matching;
 
+import java.io.InputStream;
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -186,7 +187,17 @@ public class MatcherFilter implements Filter {
         }
 
         if (body.isSet()) {
-            body.serializeTo(httpResponse, serializerChain, httpRequest);
+            try {
+                body.serializeTo(httpResponse, serializerChain, httpRequest);
+            } finally {
+                if (body.get() instanceof InputStream) {
+                    try {
+                        ((InputStream) body.get()).close();
+                    } catch (IOException e) {
+                        LOG.warn("error closing response body", e);
+                    }
+                }
+            }
         } else if (chain != null) {
             chain.doFilter(httpRequest, httpResponse);
         }


### PR DESCRIPTION
Howdy -- we ran into a situation where resources could be leaked when returning `InputStream`s from `Route.handle()`. Proposed patch below, happy to hook up tests if the approach looks reasonable.