### PR TITLE
Add support for asynchronous request handling

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -28,10 +28,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.servlet.AsyncContext;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import spark.http.matching.AsyncContextWrapper;
 import spark.routematch.RouteMatch;
 import spark.utils.urldecoding.UrlDecode;
 import spark.utils.IOUtils;
@@ -490,6 +492,15 @@ public class Request {
      */
     public String protocol() {
         return servletRequest.getProtocol();
+    }
+
+    /**
+     * Starts an asynchronous request.
+     *
+     * @return the asynchronous context
+     */
+    public AsyncContext startAsync() {
+        throw new RuntimeException("this should be not be called; use RequestWrapper.startAsync instead");
     }
 
     private static Map<String, String> getParams(List<String> request, List<String> matched) {

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
@@ -16,7 +16,9 @@
  */
 package spark.embeddedserver.jetty;
 
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.thread.ThreadPool;
+
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServerFactory;
 import spark.http.matching.MatcherFilter;
@@ -43,7 +45,11 @@ public class EmbeddedJettyFactory implements EmbeddedServerFactory {
         matcherFilter.init(null);
 
         JettyHandler handler = new JettyHandler(matcherFilter);
-        return new EmbeddedJettyServer(serverFactory, handler).withThreadPool(threadPool);
+
+        ServletContextHandler contextHandler = new ServletContextHandler(
+            null, "/", handler, null, null, null, ServletContextHandler.SESSIONS);
+
+        return new EmbeddedJettyServer(serverFactory, contextHandler).withThreadPool(threadPool);
     }
 
     /**

--- a/src/main/java/spark/http/matching/AsyncContextWrapper.java
+++ b/src/main/java/spark/http/matching/AsyncContextWrapper.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2011- Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.http.matching;
+
+import java.io.IOException;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import spark.serialization.SerializerChain;
+
+/**
+ * This class wraps the AsyncContext and adds support for calling After and AfterAfter filters
+ * when the async request is complete.
+ *
+ * @author : Steve Hurlbut
+ *
+ */
+public class AsyncContextWrapper implements AsyncContext {
+    private final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(AsyncContextWrapper.class);
+    private AsyncContext wrappedContext;
+    private RouteContext routeContext;
+    private SerializerChain serializerChain;
+
+    public AsyncContextWrapper(RouteContext routeContext,
+                               SerializerChain serializerChain) {
+        this.routeContext = routeContext;
+        this.serializerChain = serializerChain;
+    }
+
+    /**
+     * Adds an AysncContext listener that handles timeout events.
+     * @param context the wrapped context
+     */
+    public void setWrappedContext(AsyncContext context) {
+        wrappedContext = context;
+        AsyncListener listener = new AsyncListener() {
+            @Override
+            public void onComplete(AsyncEvent asyncEvent) throws IOException {
+            }
+
+            @Override
+            public void onTimeout(AsyncEvent asyncEvent) throws IOException {
+                processException(new IOException("Asynchronous request timeout expired"));
+            }
+
+            @Override
+            public void onError(AsyncEvent asyncEvent) throws IOException {
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent asyncEvent) throws IOException {
+            }
+        };
+        context.addListener(listener);
+    }
+
+
+    @Override
+    public ServletRequest getRequest() {
+        return wrappedContext.getRequest();
+    }
+
+    @Override
+    public ServletResponse getResponse() {
+        return wrappedContext.getResponse();
+    }
+
+    @Override
+    public boolean hasOriginalRequestAndResponse() {
+        return wrappedContext.hasOriginalRequestAndResponse();
+    }
+
+    @Override
+    public void dispatch() {
+        wrappedContext.dispatch();
+    }
+
+    @Override
+    public void dispatch(String s) {
+        wrappedContext.dispatch(s);
+    }
+
+    @Override
+    public void dispatch(ServletContext servletContext, String s) {
+        wrappedContext.dispatch(servletContext, s);
+
+    }
+
+    /**
+     * When the async context is complete, call the After and AfterAfter filters and process
+     * the response body.
+     */
+    @Override
+    public void complete() {
+        try {
+            try {
+                AfterFilters.execute(routeContext);
+                AfterAfterFilters.execute(routeContext);
+                if (routeContext.response().body() != null) {
+                    routeContext.body().set(routeContext.response().body());
+                }
+                if (routeContext.body().isSet()) {
+                    routeContext.body()
+                        .serializeTo(routeContext.responseWrapper().raw(), serializerChain, routeContext.httpRequest());
+                } else {
+                    routeContext.responseWrapper().raw().getOutputStream().close();
+                }
+            }
+            catch (Exception ex) {
+                processException(ex);
+            }
+        }
+        catch (IOException e) {
+            LOG.error("Error completing async request", e);
+        }
+        finally {
+            wrappedContext.complete();
+        }
+    }
+
+    @Override
+    public void start(Runnable runnable) {
+        wrappedContext.start(runnable);
+    }
+
+    @Override
+    public void addListener(AsyncListener asyncListener) {
+        wrappedContext.addListener(asyncListener);
+    }
+
+    @Override
+    public void addListener(AsyncListener asyncListener, ServletRequest servletRequest,
+                            ServletResponse servletResponse) {
+        wrappedContext.addListener(asyncListener, servletRequest, servletResponse);
+    }
+
+    @Override
+    public <T extends AsyncListener> T createListener(Class<T> aClass) throws ServletException {
+        return wrappedContext.createListener(aClass);
+    }
+
+    @Override
+    public void setTimeout(long l) {
+        wrappedContext.setTimeout(l);
+
+    }
+
+    @Override
+    public long getTimeout() {
+        return wrappedContext.getTimeout();
+    }
+
+    private void processException(Exception exception) throws IOException {
+        GeneralError.modify(
+            routeContext.httpRequest(),
+            routeContext.responseWrapper().raw(),
+            routeContext.body(),
+            routeContext.requestWrapper(),
+            routeContext.responseWrapper(),
+            exception);
+        try {
+            AfterAfterFilters.execute(routeContext);
+        }
+        catch (Exception e) {
+            LOG.error("Error processing async request", e);
+        }
+        if (routeContext.body().isSet()) {
+            routeContext.body().serializeTo(routeContext.responseWrapper().raw(), serializerChain, routeContext.httpRequest());
+        } else {
+            routeContext.responseWrapper().raw().getOutputStream().close();
+        }
+    }
+}

--- a/src/main/java/spark/http/matching/RequestWrapper.java
+++ b/src/main/java/spark/http/matching/RequestWrapper.java
@@ -19,6 +19,7 @@ package spark.http.matching;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
 
 import spark.Access;
@@ -28,6 +29,8 @@ import spark.Session;
 import spark.routematch.RouteMatch;
 
 final class RequestWrapper extends Request {
+
+    private AsyncContextWrapper asyncContextWrapper;
 
     static RequestWrapper create() {
         return new RequestWrapper();
@@ -239,5 +242,19 @@ final class RequestWrapper extends Request {
     @Override
     public String cookie(String name) {
         return delegate.cookie(name);
+    }
+
+    @Override
+    public AsyncContext startAsync() {
+        if (asyncContextWrapper != null) {
+            asyncContextWrapper.setWrappedContext(raw().startAsync());
+            return asyncContextWrapper;
+        } else {
+            return raw().startAsync();
+        }
+    }
+
+    public void setAsyncContextWrapper(AsyncContextWrapper wrapper) {
+        this.asyncContextWrapper = wrapper;
     }
 }

--- a/src/test/java/spark/AsyncRequestIntegrationTest.java
+++ b/src/test/java/spark/AsyncRequestIntegrationTest.java
@@ -1,0 +1,188 @@
+package spark;
+
+import static spark.Spark.*;
+
+import java.io.PrintWriter;
+
+import javax.servlet.AsyncContext;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import spark.util.SparkTestUtil;
+
+/**
+ * @author : Steve Hurlbut
+ */
+public class AsyncRequestIntegrationTest {
+    private static SparkTestUtil http;
+
+
+    @BeforeClass
+    public static void setup() {
+        http = new SparkTestUtil(4567);
+
+        exception(Exception.class, (exception, request, response) -> {
+            response.status(500);
+            response.body(exception.getMessage());
+        });
+
+        before("/test", (req, res) -> {
+            res.header("BeforeFilter", "true");
+        });
+
+        after("/test", (req, res) -> {
+            res.header("AfterFilter", "true");
+        });
+
+        afterAfter("/test", (req, res) -> {
+            res.header("AfterAfterFilter", "true");
+        });
+
+        // Spark style implementation of async requests
+        get("/test", (req, res) -> {
+            boolean isAsync = "true".equals(req.queryParams("async"));
+            if (isAsync) {
+                final AsyncContext ctx = req.startAsync();
+                Thread t = new Thread(() -> {
+                    try {
+                        Thread.sleep(500);
+                        res.body("Async!");
+                        ctx.complete();
+                    }
+                    catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                });
+                t.start();
+            }
+            return "completed synchronously";
+        });
+
+        get("/test/slow", (req, res) -> {
+            final AsyncContext ctx = req.startAsync();
+            ctx.setTimeout(500L);
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(2000);
+                    res.body("Async!");
+                    ctx.complete();
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            t.start();
+            return "completed synchronously";
+        });
+
+        get("/test/error", (req, res) -> {
+            final AsyncContext ctx = req.startAsync();
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(500);
+                    res.status(500);
+                    res.body("Something bad happened");
+                    ctx.complete();
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            t.start();
+            return "completed synchronously";
+        });
+
+        // servlet style implementation of async requests
+        get("/traditional", (req, res) -> {
+            final AsyncContext ctx = req.raw().startAsync();
+            Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(500);
+                    PrintWriter writer = ctx.getResponse().getWriter();
+                    writer.write("lots of data");
+                    writer.close();
+                    ctx.complete();
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+            t.start();
+            return "completed synchronously";
+        });
+
+        awaitInitialization();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        stop();
+    }
+
+    // verify synchronous requests still work
+    @Test
+    public void testSync() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/test");
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("completed synchronously", response.body);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // verify body, before, after, and afterAfter files are processed with async requests
+    @Test
+    public void testAsync() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/test?async=true");
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("Async!", response.body);
+            Assert.assertEquals("true", response.headers.get("BeforeFilter"));
+            Assert.assertEquals("true", response.headers.get("AfterFilter"));
+            Assert.assertEquals("true", response.headers.get("AfterAfterFilter"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // verify timeouts are properly handled
+    @Test
+    public void testTimeout() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/test/slow");
+            Assert.assertEquals(500, response.status);
+            Assert.assertEquals("Asynchronous request timeout expired", response.body);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // verify error handling works properly
+    @Test
+    public void testError() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/test/error");
+            Assert.assertEquals(500, response.status);
+            Assert.assertTrue(response.body.contains("Something bad happened"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // verify traditional servlet style processing of async requests works
+    @Test
+    public void testTraditional() {
+        try {
+            SparkTestUtil.UrlResponse response = http.get("/traditional");
+            Assert.assertEquals(200, response.status);
+            Assert.assertEquals("lots of data", response.body);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
See comment in: Support of event based (non-blocking) request processing. #549

Duplicated here:
Hi,

My team has been using Spark as a platform to build microservices for the last year. We have one service that is still running on Spring Boot that we would like to port to Spark, but it makes heavy use of Asynchronous Requests. We've reviewed the PR from mj1618, and don't think that it would work for our use case because we also need the ability to stream back very very large responses.

So we have come up with an alternative PR that we have tested with our application (at transaction rates of up to 3000 requests per second)

# TL;DR

This PR:
* adds support for Asyncronous Request handing using *any* Java construct you wish (threads, futures, ...)
* has no impact on existing Spark applications
* has a minimal impact on the Spark code base
* supports *both* Spark style request API's and traditional Servlet 3.0 style API's
* supports Spark After and AfterAfter filters.

# USE CASE 

I'll use our service as an example of why asyncronous request handling is needed. Our service basically exposes a set of REST API's that can be used to issue queries against any of several backend databases. The user of the REST API can submit any query they wish, so we have no idea how long the query will run or how much data it will return. It could run for 1ms and return 1 row of data or it could run for 2 hours and return a million rows of data.

In typical syncronous request processing, these queries would be running in the Jetty request thread. So if enough long running queries are submitted, we will run out of request threads. 🙁 

So instead we use asyncronous requests which free up the Jetty request thread once we have put the request on an internal queue. Then we have our own thread pool that executes database queries from the internal queue and then streams the results back to the client.

Because we are potentially returning so much data, we cannot keep  all of the response body in memory at one time. So we need to be able to stream the response directly to the output stream of the HTTP response. This is the part that doesn't work well with the existing Spark API's because they store the response body in string.

# EXAMPLE: Spark API's

Here is a simple example of a Spark Controller method that creates its own thread to use to process the request asyncronously:

```
        get("/async", (req, res) -> {
            final AsyncContext ctx = req.startAsync();
            Thread t = new Thread(() -> {
                try {
                    Thread.sleep(500);
                    res.body("Hello from Async!");
                    ctx.complete();
                }
                catch (Exception e) {
                    e.printStackTrace();
                }
            });
            t.start();
            return "";
        });
```

# EXAMPLE: Servlet 3.0 API's

Here is the same example implemented with Servlet 3.0 API's. 

```
        get("/traditional", (req, res) -> {
            final AsyncContext ctx = req.raw().startAsync();
            Thread t = new Thread(() -> {
                try {
                    Thread.sleep(500);
                    PrintWriter writer = ctx.getResponse().getWriter();
                    writer.write("lots of data");
                    writer.close();
                    ctx.complete();
                }
                catch (Exception e) {
                    e.printStackTrace();
                }
            });
            t.start();
            return "";
        });
```

Both of these approaches are supported by this PR.
