### PR TITLE
Support static files in /META-INF/resources according to Servlet Spec

### DIFF
--- a/src/main/java/spark/resource/ClassPathResource.java
+++ b/src/main/java/spark/resource/ClassPathResource.java
@@ -41,6 +41,11 @@ import spark.utils.StringUtils;
  */
 public class ClassPathResource extends AbstractFileResolvingResource {
 
+    /**
+     * Prefix of the classpath defined in Servlet 3.0 static resources location provided by dependencies.
+     */
+    private static final String SERVLET_STATIC_FILES_PREFIX = "/META-INF/resources";
+
     private final String path;
 
     private ClassLoader classLoader;
@@ -92,8 +97,10 @@ public class ClassPathResource extends AbstractFileResolvingResource {
     }
 
     private static boolean isInvalidPath(String path) {
-        if (path.contains("WEB-INF") || path.contains("META-INF")) {
-            return true;
+        if (!path.startsWith(SERVLET_STATIC_FILES_PREFIX)) {
+            if (path.contains("WEB-INF") || path.contains("META-INF")) {
+                return true;
+            }
         }
         if (path.contains(":/")) {
             String relativePath = (path.charAt(0) == '/' ? path.substring(1) : path);

--- a/src/test/java/spark/resource/ClassPathResourceTest.java
+++ b/src/test/java/spark/resource/ClassPathResourceTest.java
@@ -1,0 +1,25 @@
+package spark.resource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author jsiebahn
+ * @since 06.04.2018
+ */
+public class ClassPathResourceTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldPreventReadingFromMetaInf() {
+
+        new ClassPathResource("/META-INF/something-secret.xml");
+
+    }
+
+    @Test
+    public void shouldSupportServletSpecResources() {
+        ClassPathResource classPathResource = new ClassPathResource(
+            "/META-INF/resources/ClassPathResourceTest.css");
+        Assert.assertEquals(true, classPathResource.exists());
+    }
+}

--- a/src/test/resources/META-INF/resources/ClassPathResourceTest.css
+++ b/src/test/resources/META-INF/resources/ClassPathResourceTest.css
@@ -1,0 +1,3 @@
+.dummy {
+    /* Test file for spark.resource.ClassPathResourceTest#shouldSupportServletSpecResources() */
+}


### PR DESCRIPTION
With #981 the ClassPathResource drops paths containing `META-INF` and
`WEB-INF`. The Servlet Spec defines `/META-INF/resources` as a default
resource path to include static resources from libraries.

This pull request adds an exception for this defined path.