### PR TITLE
Use a default response transformer

### DIFF
--- a/src/main/java/spark/Routable.java
+++ b/src/main/java/spark/Routable.java
@@ -24,6 +24,8 @@ import spark.utils.SparkUtils;
  */
 abstract class Routable {
 
+    private ResponseTransformer defaultResponseTransformer;
+
     /**
      * Adds a route
      *
@@ -56,7 +58,7 @@ abstract class Routable {
      * @param route The route
      */
     public void get(String path, Route route) {
-        addRoute(HttpMethod.get, RouteImpl.create(path, route));
+        addRoute(HttpMethod.get, createRouteImpl(path, route));
     }
 
     /**
@@ -66,7 +68,7 @@ abstract class Routable {
      * @param route The route
      */
     public void post(String path, Route route) {
-        addRoute(HttpMethod.post, RouteImpl.create(path, route));
+        addRoute(HttpMethod.post, createRouteImpl(path, route));
     }
 
     /**
@@ -76,7 +78,7 @@ abstract class Routable {
      * @param route The route
      */
     public void put(String path, Route route) {
-        addRoute(HttpMethod.put, RouteImpl.create(path, route));
+        addRoute(HttpMethod.put, createRouteImpl(path, route));
     }
 
     /**
@@ -86,7 +88,7 @@ abstract class Routable {
      * @param route The route
      */
     public void patch(String path, Route route) {
-        addRoute(HttpMethod.patch, RouteImpl.create(path, route));
+        addRoute(HttpMethod.patch, createRouteImpl(path, route));
     }
 
     /**
@@ -96,7 +98,7 @@ abstract class Routable {
      * @param route The route
      */
     public void delete(String path, Route route) {
-        addRoute(HttpMethod.delete, RouteImpl.create(path, route));
+        addRoute(HttpMethod.delete, createRouteImpl(path, route));
     }
 
     /**
@@ -106,7 +108,7 @@ abstract class Routable {
      * @param route The route
      */
     public void head(String path, Route route) {
-        addRoute(HttpMethod.head, RouteImpl.create(path, route));
+        addRoute(HttpMethod.head, createRouteImpl(path, route));
     }
 
     /**
@@ -116,7 +118,7 @@ abstract class Routable {
      * @param route The route
      */
     public void trace(String path, Route route) {
-        addRoute(HttpMethod.trace, RouteImpl.create(path, route));
+        addRoute(HttpMethod.trace, createRouteImpl(path, route));
     }
 
     /**
@@ -126,7 +128,7 @@ abstract class Routable {
      * @param route The route
      */
     public void connect(String path, Route route) {
-        addRoute(HttpMethod.connect, RouteImpl.create(path, route));
+        addRoute(HttpMethod.connect, createRouteImpl(path, route));
     }
 
     /**
@@ -136,7 +138,7 @@ abstract class Routable {
      * @param route The route
      */
     public void options(String path, Route route) {
-        addRoute(HttpMethod.options, RouteImpl.create(path, route));
+        addRoute(HttpMethod.options, createRouteImpl(path, route));
     }
 
     /**
@@ -171,7 +173,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void get(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.get, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.get, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -182,7 +184,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void post(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.post, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.post, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -193,7 +195,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void put(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.put, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.put, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -204,7 +206,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void patch(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.patch, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.patch, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -215,7 +217,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void delete(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.delete, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.delete, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -226,7 +228,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void head(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.head, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.head, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -237,7 +239,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void trace(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.trace, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.trace, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -248,7 +250,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void connect(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.connect, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.connect, createRouteImpl(path, acceptType, route));
     }
 
     /**
@@ -259,7 +261,7 @@ abstract class Routable {
      * @param route      The route
      */
     public void options(String path, String acceptType, Route route) {
-        addRoute(HttpMethod.options, RouteImpl.create(path, acceptType, route));
+        addRoute(HttpMethod.options, createRouteImpl(path, acceptType, route));
     }
 
 
@@ -793,4 +795,41 @@ abstract class Routable {
         addRoute(HttpMethod.patch, ResponseTransformerRouteImpl.create(path, acceptType, route, transformer));
     }
 
+    /**
+     * Create route implementation or use default response transformer
+     *
+     * @param path       the path
+     * @param acceptType the accept type
+     * @param route      the route
+     * @return ResponseTransformerRouteImpl or RouteImpl
+     */
+    private RouteImpl createRouteImpl(String path, String acceptType, Route route) {
+        if (defaultResponseTransformer != null) {
+            return ResponseTransformerRouteImpl.create(path, acceptType, route, defaultResponseTransformer);
+        }
+        return RouteImpl.create(path, acceptType, route);
+    }
+
+    /**
+     * Create route implementation or use default response transformer
+     *
+     * @param path  the path
+     * @param route the route
+     * @return ResponseTransformerRouteImpl or RouteImpl
+     */
+    private RouteImpl createRouteImpl(String path, Route route) {
+        if (defaultResponseTransformer != null) {
+            return ResponseTransformerRouteImpl.create(path, route, defaultResponseTransformer);
+        }
+        return RouteImpl.create(path, route);
+    }
+
+    /**
+     * Sets default response transformer
+     *
+     * @param transformer
+     */
+    public void defaultResponseTransformer(ResponseTransformer transformer) {
+        defaultResponseTransformer = transformer;
+    }
 }

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -16,18 +16,8 @@
  */
 package spark;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServers;
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerClassWrapper;
@@ -39,6 +29,11 @@ import spark.route.ServletRoutes;
 import spark.ssl.SslStores;
 import spark.staticfiles.MimeType;
 import spark.staticfiles.StaticFilesConfiguration;
+
+import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static spark.globalstate.ServletFlag.isRunningFromServlet;
@@ -265,7 +260,7 @@ public final class Service extends Routable {
 
         if (keystoreFile == null) {
             throw new IllegalArgumentException(
-                    "Must provide a keystore file to run secured");
+                "Must provide a keystore file to run secured");
         }
 
         sslStores = SslStores.create(keystoreFile, keystorePassword, certAlias, truststoreFile, truststorePassword, needsClientCert);
@@ -313,7 +308,7 @@ public final class Service extends Routable {
         if (initialized && !isRunningFromServlet()) {
             throwBeforeRouteMappingException();
         }
-        
+
         if (!staticFilesConfiguration.isStaticResourcesSet()) {
             staticFilesConfiguration.configure(folder);
         } else {
@@ -333,7 +328,7 @@ public final class Service extends Routable {
         if (initialized && !isRunningFromServlet()) {
             throwBeforeRouteMappingException();
         }
-        
+
         if (!staticFilesConfiguration.isExternalStaticResourcesSet()) {
             staticFilesConfiguration.configureExternal(externalFolder);
         } else {
@@ -436,7 +431,7 @@ public final class Service extends Routable {
      */
     public void awaitInitialization() {
         if (!initialized) {
-    	        throw new IllegalStateException("Server has not been properly initialized");
+            throw new IllegalStateException("Server has not been properly initialized");
         }
 
         try {
@@ -449,7 +444,7 @@ public final class Service extends Routable {
 
     private void throwBeforeRouteMappingException() {
         throw new IllegalStateException(
-                "This must be done before route mapping has begun");
+            "This must be done before route mapping has begun");
     }
 
     private boolean hasMultipleHandlers() {
@@ -466,7 +461,7 @@ public final class Service extends Routable {
                 server.extinguish();
                 latch = new CountDownLatch(1);
             }
-            
+
             routes.clear();
             exceptionMapper.clear();
             staticFilesConfiguration.clear();
@@ -532,30 +527,30 @@ public final class Service extends Routable {
 
             if (!isRunningFromServlet()) {
                 new Thread(() -> {
-                  try {
-                    EmbeddedServers.initialize();
+                    try {
+                        EmbeddedServers.initialize();
 
-                    if (embeddedServerIdentifier == null) {
-                        embeddedServerIdentifier = EmbeddedServers.defaultIdentifier();
-                    }
+                        if (embeddedServerIdentifier == null) {
+                            embeddedServerIdentifier = EmbeddedServers.defaultIdentifier();
+                        }
 
-                    server = EmbeddedServers.create(embeddedServerIdentifier,
-                                                    routes,
-                                                    staticFilesConfiguration,
-                                                    hasMultipleHandlers());
+                        server = EmbeddedServers.create(embeddedServerIdentifier,
+                            routes,
+                            staticFilesConfiguration,
+                            hasMultipleHandlers());
 
-                    server.configureWebSockets(webSocketHandlers, webSocketIdleTimeoutMillis);
+                        server.configureWebSockets(webSocketHandlers, webSocketIdleTimeoutMillis);
 
-                    port = server.ignite(
+                        port = server.ignite(
                             ipAddress,
                             port,
                             sslStores,
                             maxThreads,
                             minThreads,
                             threadIdleTimeoutMillis);
-                  } catch (Exception e) {
-                    initExceptionHandler.accept(e);
-                  }
+                    } catch (Exception e) {
+                        initExceptionHandler.accept(e);
+                    }
                     try {
                         latch.countDown();
                         server.join();

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -4,7 +4,7 @@
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -953,6 +953,15 @@ public class Spark {
     }
 
     /**
+     * Set the default response transformer. All requests not using a custom transformer will use this one
+     *
+     * @param transformer
+     */
+    public static void setDefaultResponseTransformer(ResponseTransformer transformer) {
+        getInstance().defaultResponseTransformer(transformer);
+    }
+
+    /**
      * Set the port that Spark should listen on. If not called the default port
      * is 4567. This has to be called before any route mapping is done.
      * If provided port = 0 then the an arbitrary available port will be used.
@@ -1062,8 +1071,8 @@ public class Spark {
     public static void initExceptionHandler(Consumer<Exception> initExceptionHandler) {
         getInstance().initExceptionHandler(initExceptionHandler);
     }
-     
-    /** 
+
+    /**
      * Set the connection to be secure, using the specified keystore and
      * truststore. This has to be called before any route mapping is done. You
      * have to supply a keystore file, truststore file is optional (keystore

--- a/src/test/java/spark/examples/transformer/DefaultTransformerExample.java
+++ b/src/test/java/spark/examples/transformer/DefaultTransformerExample.java
@@ -1,0 +1,21 @@
+package spark.examples.transformer;
+
+import static spark.Spark.get;
+import static spark.Spark.setDefaultResponseTransformer;
+
+public class DefaultTransformerExample {
+
+    public static void main(String args[]) {
+
+        setDefaultResponseTransformer(new JsonTransformer());
+
+        get("/hello", "application/json", (request, response) -> {
+            return new MyMessage("Hello World");
+        });
+
+        get("/hello2", "application/json", (request, response) -> {
+            return new MyMessage("Hello World");
+        }, model -> "custom transformer");
+    }
+
+}


### PR DESCRIPTION
I would find it useful to add a default response transformer. I'm using spark as a REST API thus all my responses should be json.

`setDefaultResponseTransformer(new JsonTransformer());`

_I also removed some unused imports from `Service.java` (and applied formatting)_