### PR TITLE
Set HttpOnly for session cookie due to improvement of security

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
@@ -29,6 +29,7 @@ import spark.staticfiles.StaticFilesConfiguration;
 public class EmbeddedJettyFactory implements EmbeddedServerFactory {
     private final JettyServerFactory serverFactory;
     private ThreadPool threadPool;
+    private boolean httpOnly = true;
 
     public EmbeddedJettyFactory() {
         this.serverFactory = new JettyServer();
@@ -43,7 +44,7 @@ public class EmbeddedJettyFactory implements EmbeddedServerFactory {
         matcherFilter.init(null);
 
         JettyHandler handler = new JettyHandler(matcherFilter);
-		handler.getSessionCookieConfig().setHttpOnly(true);
+		handler.getSessionCookieConfig().setHttpOnly(httpOnly);
         return new EmbeddedJettyServer(serverFactory, handler).withThreadPool(threadPool);
     }
 
@@ -55,6 +56,11 @@ public class EmbeddedJettyFactory implements EmbeddedServerFactory {
      */
     public EmbeddedJettyFactory withThreadPool(ThreadPool threadPool) {
         this.threadPool = threadPool;
+        return this;
+    }
+
+    public EmbeddedJettyFactory withHttpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
         return this;
     }
 }


### PR DESCRIPTION
This is an improvement for PR https://github.com/perwendel/spark/pull/965 from @M-Razavi

In this PR, I
1. I made it possible to disable `HttpOnly` flag (just in case, probably somebody will need it).
2. Added unit-tests.
