### PR TITLE
Make Jetty Server simple to configure

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyFactory.java
@@ -16,6 +16,9 @@
  */
 package spark.embeddedserver.jetty;
 
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
 import spark.ExceptionMapper;
@@ -25,37 +28,62 @@ import spark.http.matching.MatcherFilter;
 import spark.route.Routes;
 import spark.staticfiles.StaticFilesConfiguration;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
 /**
  * Creates instances of embedded jetty containers.
  */
 public class EmbeddedJettyFactory implements EmbeddedServerFactory {
-    private final JettyServerFactory serverFactory;
+    private final ConfigurableJettyServerFactory serverFactory;
+    private final List<Handler> handlersBeforeRouteHandler = new ArrayList<>();
     private ThreadPool threadPool;
     private boolean httpOnly = true;
 
     public EmbeddedJettyFactory() {
-        this.serverFactory = new JettyServer();
+        this(new JettyServer());
     }
 
     public EmbeddedJettyFactory(JettyServerFactory serverFactory) {
-        this.serverFactory = serverFactory;
+        this.serverFactory = new ConfigurableJettyServerFactory(serverFactory);
     }
 
     public EmbeddedServer create(Routes routeMatcher,
                                  StaticFilesConfiguration staticFilesConfiguration,
                                  ExceptionMapper exceptionMapper,
                                  boolean hasMultipleHandler) {
+        Handler handler = getHandler(routeMatcher, staticFilesConfiguration, exceptionMapper, hasMultipleHandler);
+
+        return new EmbeddedJettyServer(serverFactory, handler).withThreadPool(threadPool);
+    }
+
+    private Handler getHandler(Routes routeMatcher,
+                               StaticFilesConfiguration staticFilesConfiguration,
+                               ExceptionMapper exceptionMapper,
+                               boolean hasMultipleHandler) {
         MatcherFilter matcherFilter = new MatcherFilter(routeMatcher, staticFilesConfiguration, exceptionMapper, false, hasMultipleHandler);
         matcherFilter.init(null);
 
         JettyHandler handler = new JettyHandler(matcherFilter);
         handler.getSessionCookieConfig().setHttpOnly(httpOnly);
-        return new EmbeddedJettyServer(serverFactory, handler).withThreadPool(threadPool);
+
+        if (handlersBeforeRouteHandler.isEmpty()) {
+            return handler;
+        } else {
+            Handler[] handlers = handlersBeforeRouteHandler.toArray(new Handler[0]);
+            HandlerList handlerList = new HandlerList(handlers);
+            handlerList.addHandler(handler);
+            return handlerList;
+        }
     }
 
     /**
-     * Sets optional thread pool for jetty server.  This is useful for overriding the default thread pool
-     * behaviour for example io.dropwizard.metrics.jetty9.InstrumentedQueuedThreadPool.
+     * Sets optional thread pool for jetty server.
+     * This is useful for overriding the default thread pool behaviour for
+     * example io.dropwizard.metrics.jetty9.InstrumentedQueuedThreadPool.
      *
      * @param threadPool thread pool
      * @return Builder pattern - returns this instance
@@ -65,8 +93,100 @@ public class EmbeddedJettyFactory implements EmbeddedServerFactory {
         return this;
     }
 
+    /**
+     * Marks or unmarks the session tracking cookies as <i>HttpOnly</i>.
+     * For details see: {@link javax.servlet.SessionCookieConfig#setHttpOnly(boolean)}
+     *
+     * @param httpOnly true if the session tracking cookies shall be marked as <i>HttpOnly</i>, false otherwise
+     * @return Builder pattern - returns this instance
+     */
     public EmbeddedJettyFactory withHttpOnly(boolean httpOnly) {
         this.httpOnly = httpOnly;
         return this;
+    }
+
+    /**
+     * Adds a handler to the list of handlers called by Jetty.
+     * This method may be called multiple times to add more than one handler.
+     * The handlers will be called in the order they have been added here.
+     * The {@link JettyHandler} which handles the routes will be placed at the end of these handlers
+     *
+     * @param handler the handler.
+     * @return Builder pattern - returns this instance
+     */
+    public EmbeddedJettyFactory withHandlerBeforeRouteHandler(Handler handler) {
+        this.handlersBeforeRouteHandler.add(handler);
+        return this;
+    }
+
+    /**
+     * Adds an attribute to be applied on a newly created Jetty Server.
+     * See {@link Server#setAttribute(String, Object)} for a detailed description.
+     *
+     * @param name      the name of the attribute.
+     * @param attribute the value of the attribute.
+     * @return Builder pattern - returns this instance
+     */
+    public EmbeddedJettyFactory withJettyServerAttribute(String name, Object attribute) {
+        this.serverFactory.setServerAttribute(name, attribute);
+        return this;
+    }
+
+    /**
+     * Registers a callback which will be executed after a new Jetty Server has been created.
+     * Only one callback can be registered. If this method is called multiple times only the very last
+     * callback will be executed.
+     *
+     * @param configurator a callback which is passed the newly created server instance. May be {@code null}.
+     * @return Builder pattern - returns this instance
+     */
+    public EmbeddedJettyFactory withJettyServerConfigurator(Consumer<Server> configurator) {
+        this.serverFactory.setServerConfigurator(configurator);
+        return this;
+    }
+
+    /**
+     * Wrapper class around a JettyServerFactory which allows to configure the newly created server instance.
+     */
+    private static class ConfigurableJettyServerFactory implements JettyServerFactory {
+        private final JettyServerFactory factory;
+        private final Map<String, Object> serverAttributes = new HashMap<>();
+
+        private Consumer<Server> configurator = null;
+
+        private ConfigurableJettyServerFactory(JettyServerFactory factory) {
+            this.factory = factory;
+        }
+
+        @Override
+        public Server create(int maxThreads, int minThreads, int threadTimeoutMillis) {
+            final Server server = factory.create(maxThreads, minThreads, threadTimeoutMillis);
+            return configureServer(server);
+        }
+
+        @Override
+        public Server create(ThreadPool threadPool) {
+            final Server server = factory.create(threadPool);
+            return configureServer(server);
+        }
+
+        private Server configureServer(Server server) {
+            for (Map.Entry<String, Object> entry : serverAttributes.entrySet()) {
+                server.setAttribute(entry.getKey(), entry.getValue());
+            }
+            if (configurator != null) {
+                configurator.accept(server);
+            }
+            return server;
+        }
+
+        private void setServerAttribute(String name, Object attribute) {
+            serverAttributes.put(name, attribute);
+        }
+
+        private void setServerConfigurator(Consumer<Server> configurator) {
+            this.configurator = configurator;
+        }
+
     }
 }

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -18,8 +18,6 @@ package spark.embeddedserver.jetty;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -126,16 +124,16 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         if (webSocketServletContextHandler == null) {
             server.setHandler(handler);
         } else {
-            List<Handler> handlersInList = new ArrayList<>();
-            handlersInList.add(handler);
-
-            // WebSocket handler must be the last one
-            if (webSocketServletContextHandler != null) {
-                handlersInList.add(webSocketServletContextHandler);
+            HandlerList handlers;
+            if (handler instanceof HandlerList) {
+                handlers = (HandlerList) handler;
+            } else {
+                handlers = new HandlerList(handler);
             }
 
-            HandlerList handlers = new HandlerList();
-            handlers.setHandlers(handlersInList.toArray(new Handler[handlersInList.size()]));
+            // WebSocket handler must be the last one
+            handlers.addHandler(webSocketServletContextHandler);
+
             server.setHandler(handlers);
         }
 

--- a/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
@@ -1,6 +1,8 @@
 package spark.embeddedserver.jetty;
 
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.After;
 import org.junit.Test;
@@ -10,6 +12,11 @@ import spark.embeddedserver.EmbeddedServer;
 import spark.route.Routes;
 import spark.staticfiles.StaticFilesConfiguration;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -83,16 +90,82 @@ public class EmbeddedJettyFactoryTest {
     public void create_withoutHttpOnly() throws Exception {
         final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
         final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
+        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
         final Routes routes = mock(Routes.class);
 
         Server server = new Server();
         when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
 
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withHttpOnly(false);
-        embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, false);
-        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000);
+        embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
+        embeddedServer.ignite("localhost", 6760, null, 100, 10, 10000);
 
         assertFalse(((JettyHandler) server.getHandler()).getSessionCookieConfig().isHttpOnly());
+    }
+
+    @Test
+    public void create_withAdditionalHandler() throws Exception {
+        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
+        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
+        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
+        final Routes routes = mock(Routes.class);
+        final Handler handler1 = mock(Handler.class);
+        final Handler handler2 = mock(Handler.class);
+
+        Server server = new Server();
+        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
+
+        final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory)
+            .withHandlerBeforeRouteHandler(handler1)
+            .withHandlerBeforeRouteHandler(handler2);
+        embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
+        embeddedServer.ignite("localhost", 6761, null, 100, 10, 10000);
+
+        final Handler actual = server.getHandler();
+        assertTrue(actual instanceof HandlerList);
+        final Handler[] handlers = ((HandlerList) actual).getHandlers();
+        assertEquals(3, handlers.length);
+        assertEquals(handler1, handlers[0]);
+        assertEquals(handler2, handlers[1]);
+        assertTrue(handlers[2] instanceof JettyHandler);
+    }
+
+    @Test
+    public void create_withServerAttribute() throws Exception {
+        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
+        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
+        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
+        final Routes routes = mock(Routes.class);
+
+        Server server = new Server();
+        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
+
+        final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withJettyServerAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", 500);
+        embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
+        embeddedServer.ignite("localhost", 6762, null, 100, 10, 10000);
+
+        assertEquals(500, server.getAttribute("org.eclipse.jetty.server.Request.maxFormContentSize"));
+    }
+
+    @Test
+    public void create_withConfigurator() throws Exception {
+        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
+        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
+        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
+        final Routes routes = mock(Routes.class);
+
+        Server server = new Server();
+        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
+
+        final List<Server> configuredServers = new ArrayList<>();
+        Consumer<Server> configurator = configuredServers::add;
+
+        final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withJettyServerConfigurator(configurator);
+        embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
+        embeddedServer.ignite("localhost", 6763, null, 100, 10, 10000);
+
+        assertEquals(1, configuredServers.size());
+        assertEquals(server, configuredServers.get(0));
     }
 
     @After


### PR DESCRIPTION
Goal of this change is to simplify the configuration of the embedded Jetty server.

This is achieved by adding more configuration options to the EmbeddedJettyFactory.

`withHandlerBeforeRouteHandler(Handler handler)`
Allows to register Handlers which are executed before the Handler handling the spark routes.

`withJettyServerAttribute(String name, Object attribute)`
Allows to register attributes which are set onto a newly created jetty server instance.

`withJettyServerConfigurator(Consumer<Server> configurator)`
Allows to register a callback which will be triggered whenever a new jetty server instance is created.