### PR TITLE
Expose get/set on Service.embeddedServerIdentifier

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -79,7 +79,7 @@ public final class Service extends Routable {
     private CountDownLatch initLatch = new CountDownLatch(1);
     private CountDownLatch stopLatch = new CountDownLatch(0);
 
-    private Object embeddedServerIdentifier = null;
+    private Object embeddedServerIdentifier = EmbeddedServers.defaultIdentifier();
 
     public final Redirect redirect;
     public final StaticFiles staticFiles;
@@ -112,6 +112,29 @@ public final class Service extends Routable {
         } else {
             staticFilesConfiguration = StaticFilesConfiguration.create();
         }
+    }
+
+    /**
+     * Set the identifier used to select the EmbeddedServer;
+     * null for the default.
+     *
+     * @param obj the identifier passed to {@link EmbeddedServers}.
+     */
+    public synchronized void embeddedServerIdentifier(Object obj) {
+        if (initialized) {
+            throwBeforeRouteMappingException();
+        }
+        embeddedServerIdentifier = obj;
+    }
+
+    /**
+     * Get the identifier used to select the EmbeddedServer;
+     * null for the default.
+     *
+     * @param obj the identifier passed to {@link EmbeddedServers}.
+     */
+    public synchronized Object embeddedServerIdentifier() {
+        return embeddedServerIdentifier;
     }
 
     /**

--- a/src/test/java/spark/ServiceTest.java
+++ b/src/test/java/spark/ServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 
 import spark.embeddedserver.EmbeddedServer;
+import spark.embeddedserver.EmbeddedServers;
 import spark.route.Routes;
 import spark.ssl.SslStores;
 
@@ -32,6 +33,32 @@ public class ServiceTest {
     @Before
     public void test() {
         service = ignite();
+    }
+
+    @Test
+    public void testEmbeddedServerIdentifier_defaultAndSet() {
+        assertEquals("Should return defaultIdentifier()",
+            EmbeddedServers.defaultIdentifier(),
+            service.embeddedServerIdentifier());
+
+        Object obj = new Object();
+
+        service.embeddedServerIdentifier(obj);
+
+        assertEquals("Should return expected obj",
+            obj,
+            service.embeddedServerIdentifier());
+    }
+
+    @Test
+    public void testEmbeddedServerIdentifier_thenThrowIllegalStateException() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("This must be done before route mapping has begun");
+
+        Object obj = new Object();
+
+        Whitebox.setInternalState(service, "initialized", true);
+        service.embeddedServerIdentifier(obj);
     }
 
     @Test(expected = HaltException.class)


### PR DESCRIPTION
Expose embeddeServerIdentifier, so that EmbeddedServers can be used to attach a different factory service to embedded Spark servers.