### PR TITLE
Update RouteEntry to support single wildcard.

### DIFF
--- a/src/main/java/spark/route/RouteEntry.java
+++ b/src/main/java/spark/route/RouteEntry.java
@@ -57,6 +57,10 @@ class RouteEntry {
     }
 
     private boolean matchPath(String path) { // NOSONAR
+        if (this.path.equals("*")){
+            // This path is a single wildcard and will match any path.
+            return true;
+        }
         if (!this.path.endsWith("*") && ((path.endsWith("/") && !this.path.endsWith("/")) // NOSONAR
                 || (this.path.endsWith("/") && !path.endsWith("/")))) {
             // One and not both ends with slash


### PR DESCRIPTION
This updates RouteEntry so that if a path is a single wildcard (ie `*`) it will be accepted as matching any string. This makes it possible to create a catch-all spark route, for example via:

```
spark.get("*", ...)
```