### PR TITLE
#1093 Support .mjs file for MIME type auto detection

### DIFF
--- a/src/main/java/spark/staticfiles/MimeType.java
+++ b/src/main/java/spark/staticfiles/MimeType.java
@@ -55,6 +55,7 @@ public class MimeType {
         mappings.put("jar", "application/java-archive");
         mappings.put("jpg", "image/jpeg");
         mappings.put("js", "application/javascript");
+        mappings.put("mjs", "application/javascript");
         mappings.put("json", "application/json");
         mappings.put("midi", "audio/x-midi");
         mappings.put("mp3", "audio/mpeg");

--- a/src/test/java/spark/StaticFilesMemberTest.java
+++ b/src/test/java/spark/StaticFilesMemberTest.java
@@ -100,6 +100,17 @@ public class StaticFilesMemberTest {
     }
 
     @Test
+    public void testStaticFileMjs() throws Exception {
+        SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/js/module.mjs", null);
+
+        String expectedContentType = response.headers.get("Content-Type");
+        Assert.assertEquals(expectedContentType, "application/javascript");
+
+        String body = response.body;
+        Assert.assertEquals("export default function () { console.log(\"Hello, I'm a .mjs file\"); }\n", body);
+    }
+
+    @Test
     public void testStaticFilePagesIndexHtml() throws Exception {
         SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/pages/index.html", null);
         Assert.assertEquals(200, response.status);
@@ -167,5 +178,4 @@ public class StaticFilesMemberTest {
         Assert.assertEquals(404, response.status);
         Assert.assertEquals(NOT_FOUND_BRO, response.body);
     }
-
 }

--- a/src/test/resources/public/js/module.mjs
+++ b/src/test/resources/public/js/module.mjs
@@ -1,0 +1,1 @@
+export default function () { console.log("Hello, I'm a .mjs file"); }


### PR DESCRIPTION
Signed-off-by: Lawrence Ching <lawrence.ching.zh@gmail.com>

---

After the fix, Chrome now can load the module file and execute successfully.
![image](https://user-images.githubusercontent.com/12114025/53252969-21024980-36fb-11e9-87a0-96d64872526e.png)

And `.mjs` file is returned as `application/json`
![image](https://user-images.githubusercontent.com/12114025/53252947-12b42d80-36fb-11e9-877c-0039f4a8613e.png)
