### PR TITLE
Get all mapped routes

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -36,6 +36,7 @@ import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.route.HttpMethod;
 import spark.route.Routes;
 import spark.route.ServletRoutes;
+import spark.routematch.RouteMatch;
 import spark.ssl.SslStores;
 import spark.staticfiles.MimeType;
 import spark.staticfiles.StaticFilesConfiguration;
@@ -314,7 +315,7 @@ public final class Service extends Routable {
         if (initialized && !isRunningFromServlet()) {
             throwBeforeRouteMappingException();
         }
-        
+
         if (!staticFilesConfiguration.isStaticResourcesSet()) {
             staticFilesConfiguration.configure(folder);
         } else {
@@ -334,7 +335,7 @@ public final class Service extends Routable {
         if (initialized && !isRunningFromServlet()) {
             throwBeforeRouteMappingException();
         }
-        
+
         if (!staticFilesConfiguration.isExternalStaticResourcesSet()) {
             staticFilesConfiguration.configureExternal(externalFolder);
         } else {
@@ -467,7 +468,7 @@ public final class Service extends Routable {
     	}
         initiateStop();
     }
-    
+
     /**
      * Waits for the Spark server to stop.
      * <b>Warning:</b> this method should not be called from a request handler.
@@ -480,7 +481,7 @@ public final class Service extends Routable {
             Thread.currentThread().interrupt();
         }
     }
-    
+
     private void initiateStop() {
     	stopLatch = new CountDownLatch(1);
         Thread stopThread = new Thread(() -> {
@@ -488,7 +489,7 @@ public final class Service extends Routable {
                 server.extinguish();
                 initLatch = new CountDownLatch(1);
             }
-            
+
             routes.clear();
             exceptionMapper.clear();
             staticFilesConfiguration.clear();
@@ -521,6 +522,12 @@ public final class Service extends Routable {
 
     public String getPaths() {
         return pathDeque.stream().collect(Collectors.joining(""));
+    }
+    /**
+     * @return all routes information from this service
+     */
+    public List<RouteMatch> getRoutes() {
+        return routes.findAll();
     }
 
     @Override

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -20,6 +20,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -16,6 +16,9 @@
  */
 package spark;
 
+import spark.routematch.RouteMatch;
+
+import java.util.List;
 import java.util.function.Consumer;
 
 import static spark.Service.ignite;
@@ -1266,10 +1269,18 @@ public class Spark {
     }
 
     /**
+     * @return All routes available
+     */
+    public static List<RouteMatch> getRoutes() {
+        return getInstance().getRoutes();
+    }
+
+    /**
      * @return The approximate number of currently active threads in the embedded Jetty server
      */
     public static int activeThreadCount() {
         return getInstance().activeThreadCount();
     }
+
 
 }

--- a/src/main/java/spark/route/Routes.java
+++ b/src/main/java/spark/route/Routes.java
@@ -114,6 +114,20 @@ public class Routes {
     }
 
     /**
+     * @return the targets
+     */
+    public List<RouteMatch> findAll() {
+        List<RouteMatch> matchSet = new ArrayList<>();
+        List<RouteEntry> routeEntries = routes;
+
+        for (RouteEntry routeEntry : routeEntries) {
+            matchSet.add(new RouteMatch(routeEntry.target, routeEntry.path, "ALL_ROUTES", routeEntry.acceptedType, routeEntry.httpMethod));
+        }
+
+        return matchSet;
+    }
+
+    /**
      * ¨Clear all routes
      */
     public void clear() {

--- a/src/main/java/spark/route/Routes.java
+++ b/src/main/java/spark/route/Routes.java
@@ -83,7 +83,7 @@ public class Routes {
     public RouteMatch find(HttpMethod httpMethod, String path, String acceptType) {
         List<RouteEntry> routeEntries = this.findTargetsForRequestedRoute(httpMethod, path);
         RouteEntry entry = findTargetWithGivenAcceptType(routeEntries, acceptType);
-        return entry != null ? new RouteMatch(entry.target, entry.path, path, acceptType) : null;
+        return entry != null ? new RouteMatch(entry.target, entry.path, path, acceptType, httpMethod) : null;
     }
 
     /**
@@ -103,10 +103,10 @@ public class Routes {
                 String bestMatch = MimeParse.bestMatch(Arrays.asList(routeEntry.acceptedType), acceptType);
 
                 if (routeWithGivenAcceptType(bestMatch)) {
-                    matchSet.add(new RouteMatch(routeEntry.target, routeEntry.path, path, acceptType));
+                    matchSet.add(new RouteMatch(routeEntry.target, routeEntry.path, path, acceptType, httpMethod));
                 }
             } else {
-                matchSet.add(new RouteMatch(routeEntry.target, routeEntry.path, path, acceptType));
+                matchSet.add(new RouteMatch(routeEntry.target, routeEntry.path, path, acceptType, httpMethod));
             }
         }
 

--- a/src/main/java/spark/routematch/RouteMatch.java
+++ b/src/main/java/spark/routematch/RouteMatch.java
@@ -16,6 +16,8 @@
  */
 package spark.routematch;
 
+import spark.route.HttpMethod;
+
 /**
  * @author Per Wendel
  */
@@ -25,13 +27,22 @@ public class RouteMatch {
     private String matchUri;
     private String requestURI;
     private String acceptType;
+    private HttpMethod httpMethod;
 
-    public RouteMatch(Object target, String matchUri, String requestUri, String acceptType) {
+    public RouteMatch(Object target, String matchUri, String requestUri, String acceptType, HttpMethod httpMethod) {
         super();
         this.target = target;
         this.matchUri = matchUri;
         this.requestURI = requestUri;
         this.acceptType = acceptType;
+        this.httpMethod = httpMethod;
+    }
+
+    /**
+     * @return the accept type
+     */
+    public HttpMethod getHttpMethod() {
+        return httpMethod;
     }
 
     /**

--- a/src/test/java/spark/MultipleServicesTest.java
+++ b/src/test/java/spark/MultipleServicesTest.java
@@ -21,8 +21,15 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import spark.route.HttpMethod;
+import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static spark.Service.ignite;
 
 /**
@@ -92,6 +99,26 @@ public class MultipleServicesTest {
         SparkTestUtil.UrlResponse response = secondClient.doMethod("GET", "/css/style.css", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Content of css file", response.body);
+    }
+
+    @Test
+    public void testGetAllRoutesFromBothServices(){
+        for(RouteMatch routeMatch : first.getRoutes()){
+            Assert.assertEquals(routeMatch.getAcceptType(), "*/*");
+            Assert.assertEquals(routeMatch.getHttpMethod(), HttpMethod.get);
+            Assert.assertEquals(routeMatch.getMatchUri(), "/hello");
+            Assert.assertEquals(routeMatch.getRequestURI(), "ALL_ROUTES");
+            Assert.assertThat(routeMatch.getTarget(), instanceOf(RouteImpl.class));
+        }
+
+        for(RouteMatch routeMatch : second.getRoutes()){
+            Assert.assertEquals(routeMatch.getAcceptType(), "*/*");
+            Assert.assertThat(routeMatch.getHttpMethod(), instanceOf(HttpMethod.class));
+            boolean isUriOnList = ("/hello/hi/uniqueforsecond").contains(routeMatch.getMatchUri());
+            Assert.assertTrue(isUriOnList);
+            Assert.assertEquals(routeMatch.getRequestURI(), "ALL_ROUTES");
+            Assert.assertThat(routeMatch.getTarget(), instanceOf(RouteImpl.class));
+        }
     }
 
     private static Service igniteFirstService() {

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -24,7 +24,7 @@ public class RequestTest {
     HttpSession httpSession;
     Request request;
 
-    RouteMatch match = new RouteMatch(null, "/hi", "/hi", "text/html");
+    RouteMatch match = new RouteMatch(null, "/hi", "/hi", "text/html", null);
 
     @Before
     public void setup() {


### PR DESCRIPTION
I want to implement #1006. 

From what I understood, adding a `httpRequest` field to `RouteMatch `and exposing a `getRoutes` method in the `Service` and `Spark `classes.

A few lines were changed to accommodate the new field. 

And a new test in `MultipleServicesTest` to check if everything is dandy. 