### PR TITLE
Namechange from matchedRouteUri to matchedPath

### DIFF
--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -57,7 +57,7 @@ public class Request {
 
     private Session session = null;
     private boolean validSession = false;
-    private String matchedRouteUri = null;
+    private String matchedPath = null;
 
 
     /* Lazy loaded stuff */
@@ -101,7 +101,7 @@ public class Request {
      */
     Request(RouteMatch match, HttpServletRequest request) {
         this.servletRequest = request;
-        this.matchedRouteUri = match.getMatchUri();
+        this.matchedPath = match.getMatchUri();
         changeMatch(match);
     }
 
@@ -122,7 +122,7 @@ public class Request {
         List<String> requestList = SparkUtils.convertRouteToList(match.getRequestURI());
         List<String> matchedList = SparkUtils.convertRouteToList(match.getMatchUri());
 
-        this.matchedRouteUri = match.getMatchUri();
+        this.matchedPath = match.getMatchUri();
         params = getParams(requestList, matchedList);
         splat = getSplat(requestList, matchedList);
     }
@@ -210,7 +210,7 @@ public class Request {
      * @return the matched route
      * Example return: "/account/:accountId"
      */
-    public String matchedRouteUri() { return this.matchedRouteUri; }
+    public String matchedPath() { return this.matchedPath; }
 
     /**
      * @return the servlet path

--- a/src/main/java/spark/http/matching/RequestWrapper.java
+++ b/src/main/java/spark/http/matching/RequestWrapper.java
@@ -72,7 +72,7 @@ final class RequestWrapper extends Request {
     }
 
     @Override
-    public String matchedRouteUri() { return delegate.matchedRouteUri(); }
+    public String matchedPath() { return delegate.matchedPath(); }
 
     @Override
     public String servletPath() {

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -2,7 +2,7 @@ package spark;
 
 import org.junit.Before;
 import org.junit.Test;
-import spark.examples.sugar.http;
+
 import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
@@ -123,7 +123,7 @@ public class RequestTest {
     @Test
     public void shouldBeAbleToGetTheMatchedPath() {
         Request request = new Request(matchWithParams, servletRequest);
-        assertEquals("Should have returned the matched route", THE_MATCHED_ROUTE, request.matchedRouteUri());
+        assertEquals("Should have returned the matched route", THE_MATCHED_ROUTE, request.matchedPath());
         try {
             http.get("/users/bob");
         } catch (Exception e) {
@@ -132,15 +132,15 @@ public class RequestTest {
     }
 
     public void shouldBeAbleToGetTheMatchedPathInBeforeFilter(Request q) {
-        assertEquals("Should have returned the matched route from the before filter", BEFORE_MATCHED_ROUTE, q.matchedRouteUri());
+        assertEquals("Should have returned the matched route from the before filter", BEFORE_MATCHED_ROUTE, q.matchedPath());
     }
 
     public void shouldBeAbleToGetTheMatchedPathInAfterFilter(Request q) {
-        assertEquals("Should have returned the matched route from the after filter", AFTER_MATCHED_ROUTE, q.matchedRouteUri());
+        assertEquals("Should have returned the matched route from the after filter", AFTER_MATCHED_ROUTE, q.matchedPath());
     }
 
     public void shouldBeAbleToGetTheMatchedPathInAfterAfterFilter(Request q) {
-        assertEquals("Should have returned the matched route from the afterafter filter", AFTERAFTER_MATCHED_ROUTE, q.matchedRouteUri());
+        assertEquals("Should have returned the matched route from the afterafter filter", AFTERAFTER_MATCHED_ROUTE, q.matchedPath());
     }
 
     @Test


### PR DESCRIPTION
Namechange from `matchedRouteUri` to `matchedPath` to better fit with current nomenclature.