### PR TITLE
Ensure InputStreamSerializer closes its streams

### DIFF
--- a/src/main/java/spark/serialization/InputStreamSerializer.java
+++ b/src/main/java/spark/serialization/InputStreamSerializer.java
@@ -37,7 +37,9 @@ class InputStreamSerializer extends Serializer {
     @Override
     public void process(OutputStream outputStream, Object element)
             throws IOException {
-        IOUtils.copy((InputStream) element, outputStream);
+        try (InputStream is = (InputStream) element) {
+            IOUtils.copy(is, outputStream);
+        }
     }
 
 }

--- a/src/test/java/spark/serialization/InputStreamSerializerTest.java
+++ b/src/test/java/spark/serialization/InputStreamSerializerTest.java
@@ -1,0 +1,47 @@
+package spark.serialization;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+
+public class InputStreamSerializerTest {
+
+    private InputStreamSerializer serializer = new InputStreamSerializer();
+
+    @Test
+    public void testProcess_copiesData() throws IOException {
+        byte[] bytes = "Hello, Spark!".getBytes();
+        ByteArrayInputStream input = new ByteArrayInputStream(bytes);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        serializer.process(output, input);
+
+        Assert.assertArrayEquals(bytes, output.toByteArray());
+    }
+
+    @Test
+    public void testProcess_closesStream() throws IOException {
+        MockInputStream input = new MockInputStream(new ByteArrayInputStream(new byte[0]));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        serializer.process(output, input);
+
+        Assert.assertTrue("Expected stream to be closed", input.closed);
+    }
+
+    private class MockInputStream extends FilterInputStream {
+
+        boolean closed = false;
+
+        private MockInputStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
Alternative version of #978 , incorporating the feedback in that PR.

This makes the InputStreamSerializer responsible for closing the streams it is passed.  Also includes a couple of simple tests.