### PR TITLE
Add matchedRoutePath to Request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
     <packaging>bundle</packaging>
-    <version>2.9.3-SNAPSHOT</version>
+    <version>2.9.2-SNAPSHOT</version>
     <name>Spark</name>
     <description>A Sinatra inspired java web framework</description>
     <url>http://www.sparkjava.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-core</artifactId>
     <packaging>bundle</packaging>
-    <version>2.9.2-SNAPSHOT</version>
+    <version>2.9.3-SNAPSHOT</version>
     <name>Spark</name>
     <description>A Sinatra inspired java web framework</description>
     <url>http://www.sparkjava.com</url>

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -16,6 +16,15 @@
  */
 package spark;
 
+import spark.routematch.RouteMatch;
+import spark.utils.IOUtils;
+import spark.utils.SparkUtils;
+import spark.utils.StringUtils;
+import spark.utils.urldecoding.UrlDecode;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -27,16 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import spark.routematch.RouteMatch;
-import spark.utils.urldecoding.UrlDecode;
-import spark.utils.IOUtils;
-import spark.utils.SparkUtils;
-import spark.utils.StringUtils;
 
 /**
  * Provides information about the HTTP request
@@ -58,6 +57,8 @@ public class Request {
     private Session session = null;
     private boolean validSession = false;
     private String matchedPath = null;
+    private String originalMatchedRoute = null;
+
 
 
     /* Lazy loaded stuff */
@@ -211,6 +212,12 @@ public class Request {
      * Example return: "/account/:accountId"
      */
     public String matchedPath() { return this.matchedPath; }
+
+    /**
+     * @return the original matched route
+     * Example return: "/account/:accountId"
+     */
+    public String originalMatchedRoute() { return this.originalMatchedRoute; }
 
     /**
      * @return the servlet path
@@ -564,4 +571,7 @@ public class Request {
         this.validSession = validSession;
     }
 
+    public void setOriginalMatchedRoute(String matchUri) {
+        this.originalMatchedRoute = matchUri;
+    }
 }

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -16,15 +16,6 @@
  */
 package spark;
 
-import spark.routematch.RouteMatch;
-import spark.utils.IOUtils;
-import spark.utils.SparkUtils;
-import spark.utils.StringUtils;
-import spark.utils.urldecoding.UrlDecode;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -36,6 +27,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import spark.routematch.RouteMatch;
+import spark.utils.IOUtils;
+import spark.utils.SparkUtils;
+import spark.utils.StringUtils;
+import spark.utils.urldecoding.UrlDecode;
 
 /**
  * Provides information about the HTTP request
@@ -219,6 +220,15 @@ public class Request {
      * Example return: "/account/:accountId"
      */
     public String matchedRoutePath() { return this.matchedRoutePath; }
+
+    /**
+     * Record the path of the matched route.
+     *
+     * @param matchedRoutePath the path of the matched route
+     */
+    public void matchedRoutePath(String matchedRoutePath) {
+        this.matchedRoutePath = matchedRoutePath;
+    }
 
     /**
      * @return the servlet path
@@ -570,9 +580,5 @@ public class Request {
      */
     void validSession(boolean validSession) {
         this.validSession = validSession;
-    }
-
-    public void matchedRoutePath(String matchedRoutePath) {
-        this.matchedRoutePath = matchedRoutePath;
     }
 }

--- a/src/main/java/spark/Request.java
+++ b/src/main/java/spark/Request.java
@@ -57,7 +57,7 @@ public class Request {
     private Session session = null;
     private boolean validSession = false;
     private String matchedPath = null;
-    private String originalMatchedRoute = null;
+    private String matchedRoutePath = null;
 
 
 
@@ -214,10 +214,11 @@ public class Request {
     public String matchedPath() { return this.matchedPath; }
 
     /**
-     * @return the original matched route
+     * @return the path of the matched route if a route was matched else null
+     *  always null in a before filter
      * Example return: "/account/:accountId"
      */
-    public String originalMatchedRoute() { return this.originalMatchedRoute; }
+    public String matchedRoutePath() { return this.matchedRoutePath; }
 
     /**
      * @return the servlet path
@@ -571,7 +572,7 @@ public class Request {
         this.validSession = validSession;
     }
 
-    public void setOriginalMatchedRoute(String matchUri) {
-        this.originalMatchedRoute = matchUri;
+    public void matchedRoutePath(String matchedRoutePath) {
+        this.matchedRoutePath = matchedRoutePath;
     }
 }

--- a/src/main/java/spark/http/matching/RequestWrapper.java
+++ b/src/main/java/spark/http/matching/RequestWrapper.java
@@ -16,15 +16,16 @@
  */
 package spark.http.matching;
 
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
 import spark.Access;
 import spark.QueryParamsMap;
 import spark.Request;
 import spark.Session;
 import spark.routematch.RouteMatch;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Map;
-import java.util.Set;
 
 final class RequestWrapper extends Request {
 
@@ -75,6 +76,9 @@ final class RequestWrapper extends Request {
 
     @Override
     public String matchedRoutePath() { return delegate.matchedRoutePath(); }
+
+    @Override
+    public void matchedRoutePath(String matchedRoutePath) { delegate.matchedRoutePath(matchedRoutePath); }
 
     @Override
     public String servletPath() {
@@ -245,7 +249,4 @@ final class RequestWrapper extends Request {
     public String cookie(String name) {
         return delegate.cookie(name);
     }
-
-    @Override
-    public void matchedRoutePath(String matchedRoutePath) { delegate.matchedRoutePath(matchedRoutePath); }
 }

--- a/src/main/java/spark/http/matching/RequestWrapper.java
+++ b/src/main/java/spark/http/matching/RequestWrapper.java
@@ -74,7 +74,7 @@ final class RequestWrapper extends Request {
     public String matchedPath() { return delegate.matchedPath(); }
 
     @Override
-    public String originalMatchedRoute() { return delegate.originalMatchedRoute(); }
+    public String matchedRoutePath() { return delegate.matchedRoutePath(); }
 
     @Override
     public String servletPath() {
@@ -247,5 +247,5 @@ final class RequestWrapper extends Request {
     }
 
     @Override
-    public void setOriginalMatchedRoute(String matchUri) { delegate.setOriginalMatchedRoute(matchUri); }
+    public void matchedRoutePath(String matchedRoutePath) { delegate.matchedRoutePath(matchedRoutePath); }
 }

--- a/src/main/java/spark/http/matching/RequestWrapper.java
+++ b/src/main/java/spark/http/matching/RequestWrapper.java
@@ -16,16 +16,15 @@
  */
 package spark.http.matching;
 
-import java.util.Map;
-import java.util.Set;
-
-import javax.servlet.http.HttpServletRequest;
-
 import spark.Access;
 import spark.QueryParamsMap;
 import spark.Request;
 import spark.Session;
 import spark.routematch.RouteMatch;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Set;
 
 final class RequestWrapper extends Request {
 
@@ -73,6 +72,9 @@ final class RequestWrapper extends Request {
 
     @Override
     public String matchedPath() { return delegate.matchedPath(); }
+
+    @Override
+    public String originalMatchedRoute() { return delegate.originalMatchedRoute(); }
 
     @Override
     public String servletPath() {
@@ -243,4 +245,7 @@ final class RequestWrapper extends Request {
     public String cookie(String name) {
         return delegate.cookie(name);
     }
+
+    @Override
+    public void setOriginalMatchedRoute(String matchUri) { delegate.setOriginalMatchedRoute(matchUri); }
 }

--- a/src/main/java/spark/http/matching/Routes.java
+++ b/src/main/java/spark/http/matching/Routes.java
@@ -56,6 +56,7 @@ final class Routes {
                     context.requestWrapper().changeMatch(match);
                 }
 
+                context.requestWrapper().setOriginalMatchedRoute(match.getMatchUri());
                 context.responseWrapper().setDelegate(context.response());
 
                 Object element = route.handle(context.requestWrapper(), context.responseWrapper());

--- a/src/main/java/spark/http/matching/Routes.java
+++ b/src/main/java/spark/http/matching/Routes.java
@@ -56,7 +56,7 @@ final class Routes {
                     context.requestWrapper().changeMatch(match);
                 }
 
-                context.requestWrapper().setOriginalMatchedRoute(match.getMatchUri());
+                context.requestWrapper().matchedRoutePath(match.getMatchUri());
                 context.responseWrapper().setDelegate(context.response());
 
                 Object element = route.handle(context.requestWrapper(), context.responseWrapper());

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -31,6 +31,7 @@ import static spark.Spark.afterAfter;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.before;
 import static spark.Spark.get;
+import static spark.utils.SparkUtils.ALL_PATHS;
 
 public class RequestTest {
 
@@ -146,7 +147,7 @@ public class RequestTest {
     }
 
     @Test
-    public void shouldBeAbleToGetTheOriginalMatchedPathInAfterAfter() throws Exception {
+    public void shouldBeAbleToGetTheOriginalMatchedRouteInAfterAfter() throws Exception {
         final AtomicReference<String> matchedPath = new AtomicReference<>();
         final AtomicReference<String> originalMatchedRoute = new AtomicReference<>();
         afterAfter((q, p) -> {
@@ -157,7 +158,7 @@ public class RequestTest {
         http.get("/users/bob");
 
         assertNotNull(matchedPath.get());
-        assertThat(matchedPath.get(), is("+/*paths"));
+        assertThat(matchedPath.get(), is(ALL_PATHS));
 
         assertNotNull(originalMatchedRoute.get());
         assertThat(originalMatchedRoute.get(), is(THE_MATCHED_ROUTE));

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -31,7 +31,6 @@ import static spark.Spark.afterAfter;
 import static spark.Spark.awaitInitialization;
 import static spark.Spark.before;
 import static spark.Spark.get;
-import static spark.utils.SparkUtils.ALL_PATHS;
 
 public class RequestTest {
 
@@ -147,21 +146,68 @@ public class RequestTest {
     }
 
     @Test
-    public void shouldBeAbleToGetTheOriginalMatchedRouteInAfterAfter() throws Exception {
-        final AtomicReference<String> matchedPath = new AtomicReference<>();
-        final AtomicReference<String> originalMatchedRoute = new AtomicReference<>();
-        afterAfter((q, p) -> {
-            matchedPath.set(q.matchedPath());
-            originalMatchedRoute.set(q.originalMatchedRoute());
+    public void matchedRoutePathShouldBeNullInBefore() throws Exception {
+        final AtomicReference<String> matchedRoutePath = new AtomicReference<>();
+        before((q, p) -> {
+            matchedRoutePath.set(q.matchedRoutePath());
         });
 
         http.get("/users/bob");
 
-        assertNotNull(matchedPath.get());
-        assertThat(matchedPath.get(), is(ALL_PATHS));
+        assertNull(matchedRoutePath.get());
+    }
 
-        assertNotNull(originalMatchedRoute.get());
-        assertThat(originalMatchedRoute.get(), is(THE_MATCHED_ROUTE));
+    @Test
+    public void matchedRoutePathShouldBeNullWhenNoMatches() throws Exception {
+        final AtomicReference<String> matchedRoutePath = new AtomicReference<>();
+        after((q, p) -> {
+            matchedRoutePath.set(q.matchedRoutePath());
+        });
+
+        http.get("/i/am/a/test");
+
+        assertNull(matchedRoutePath.get());
+    }
+
+    @Test
+    public void shouldBeAbleToGetTheMatchedRoutePathInRequest() throws Exception {
+        final AtomicReference<String> matchedRoutePath = new AtomicReference<>();
+        String path = "/test/route/2";
+        get(path, (q, p) -> {
+            matchedRoutePath.set(q.matchedRoutePath());
+            return "";
+        });
+
+        http.get(path);
+
+        assertNotNull(matchedRoutePath.get());
+        assertThat(matchedRoutePath.get(), is(path));
+    }
+
+    @Test
+    public void shouldBeAbleToGetTheMatchedRoutePathInAfter() throws Exception {
+        final AtomicReference<String> matchedRoutePath = new AtomicReference<>();
+        after((q, p) -> {
+            matchedRoutePath.set(q.matchedRoutePath());
+        });
+
+        http.get("/users/bob");
+
+        assertNotNull(matchedRoutePath.get());
+        assertThat(matchedRoutePath.get(), is(THE_MATCHED_ROUTE));
+    }
+
+    @Test
+    public void shouldBeAbleToGetTheMatchedRoutePathInAfterAfter() throws Exception {
+        final AtomicReference<String> matchedRoutePath = new AtomicReference<>();
+        afterAfter((q, p) -> {
+            matchedRoutePath.set(q.matchedRoutePath());
+        });
+
+        http.get("/users/bob");
+
+        assertNotNull(matchedRoutePath.get());
+        assertThat(matchedRoutePath.get(), is(THE_MATCHED_ROUTE));
     }
 
     public void shouldBeAbleToGetTheMatchedPathInBeforeFilter(Request q) {

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -1,19 +1,22 @@
 package spark;
 
-import org.junit.Before;
-import org.junit.Test;
-import spark.routematch.RouteMatch;
-import spark.util.SparkTestUtil;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import spark.routematch.RouteMatch;
+import spark.util.SparkTestUtil;
+import spark.utils.SparkUtils;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -66,6 +69,9 @@ public class RequestTest {
         afterAfter(AFTERAFTER_MATCHED_ROUTE, (q, a) -> {
             System.out.println("afterafter filter matched");
             shouldBeAbleToGetTheMatchedPathInAfterAfterFilter(q);
+        });
+        afterAfter((q, a) -> {
+            shouldBeAbleToGetTheMatchedPathWhenAllPathsAfterAfterFilter(q);
         });
 
         awaitInitialization();
@@ -145,6 +151,22 @@ public class RequestTest {
         }
     }
 
+    public void shouldBeAbleToGetTheMatchedPathInBeforeFilter(Request q) {
+        assertEquals("Should have returned the matched route from the before filter", BEFORE_MATCHED_ROUTE, q.matchedPath());
+    }
+
+    public void shouldBeAbleToGetTheMatchedPathInAfterFilter(Request q) {
+        assertEquals("Should have returned the matched route from the after filter", AFTER_MATCHED_ROUTE, q.matchedPath());
+    }
+
+    public void shouldBeAbleToGetTheMatchedPathInAfterAfterFilter(Request q) {
+        assertEquals("Should have returned the matched route from the afterafter filter", AFTERAFTER_MATCHED_ROUTE, q.matchedPath());
+    }
+
+    private void shouldBeAbleToGetTheMatchedPathWhenAllPathsAfterAfterFilter(Request q) {
+        assertEquals("Should have returned 'ALL_PATHS' from the afterafter filter", SparkUtils.ALL_PATHS, q.matchedPath());
+    }
+
     @Test
     public void matchedRoutePathShouldBeNullInBefore() throws Exception {
         final AtomicReference<String> matchedRoutePath = new AtomicReference<>();
@@ -208,18 +230,6 @@ public class RequestTest {
 
         assertNotNull(matchedRoutePath.get());
         assertThat(matchedRoutePath.get(), is(THE_MATCHED_ROUTE));
-    }
-
-    public void shouldBeAbleToGetTheMatchedPathInBeforeFilter(Request q) {
-        assertEquals("Should have returned the matched route from the before filter", BEFORE_MATCHED_ROUTE, q.matchedPath());
-    }
-
-    public void shouldBeAbleToGetTheMatchedPathInAfterFilter(Request q) {
-        assertEquals("Should have returned the matched route from the after filter", AFTER_MATCHED_ROUTE, q.matchedPath());
-    }
-
-    public void shouldBeAbleToGetTheMatchedPathInAfterAfterFilter(Request q) {
-        assertEquals("Should have returned the matched route from the afterafter filter", AFTERAFTER_MATCHED_ROUTE, q.matchedPath());
     }
 
     @Test

--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -2,21 +2,35 @@ package spark;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import spark.routematch.RouteMatch;
 import spark.util.SparkTestUtil;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static spark.Spark.*;
+import static spark.Spark.after;
+import static spark.Spark.afterAfter;
+import static spark.Spark.awaitInitialization;
+import static spark.Spark.before;
+import static spark.Spark.get;
 
 public class RequestTest {
 
@@ -129,6 +143,24 @@ public class RequestTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void shouldBeAbleToGetTheOriginalMatchedPathInAfterAfter() throws Exception {
+        final AtomicReference<String> matchedPath = new AtomicReference<>();
+        final AtomicReference<String> originalMatchedRoute = new AtomicReference<>();
+        afterAfter((q, p) -> {
+            matchedPath.set(q.matchedPath());
+            originalMatchedRoute.set(q.originalMatchedRoute());
+        });
+
+        http.get("/users/bob");
+
+        assertNotNull(matchedPath.get());
+        assertThat(matchedPath.get(), is("+/*paths"));
+
+        assertNotNull(originalMatchedRoute.get());
+        assertThat(originalMatchedRoute.get(), is(THE_MATCHED_ROUTE));
     }
 
     public void shouldBeAbleToGetTheMatchedPathInBeforeFilter(Request q) {


### PR DESCRIPTION
We're in the processing of adding request tracing to all of our java systems, all of which are using Spark as their web framework. To do so we implemented global `before` and an `afterAfter` filter which records information about the request and the response and sends it off to our tracing implementation. After the first version was released we noticed an improvement could be made by sanitizing paths params and using the route parameter key as the cleaned version. 

This technique was noted in https://github.com/perwendel/spark/issues/959 and https://github.com/perwendel/spark/issues/1048 with https://github.com/perwendel/spark/pull/1049 appearing to close both those issues. 

The problem for our use case occurs because we implement automatic tracing of requests as `ALL_PATHS` filters. This becomes a problem because `matchedUri()` in a global `after` filter will return all paths and not that actual matched route path (https://github.com/perwendel/spark/pull/1049#issuecomment-421309271).

The proposal in this PR is to introduce a new field called `matchedRoutePath` with a getter and setter. The setter records the path during the route execution so it is available in the getter for `after` and `afterAfter` filters to use.