### PR TITLE
Initiate the servlet instance in exception mapper

### DIFF
--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -24,7 +24,7 @@ public class ExceptionMapper {
     /**
      * Holds an exception mapper instance for use in servlet mode
      */
-    private static ExceptionMapper servletInstance;
+    private static ExceptionMapper servletInstance = new ExceptionMapper();;
 
     @Deprecated
     public static ExceptionMapper getInstance() {
@@ -37,9 +37,6 @@ public class ExceptionMapper {
      * @return servlet instance
      */
     public synchronized static ExceptionMapper getServletInstance() {
-        if (servletInstance == null) {
-            servletInstance = new ExceptionMapper();
-        }
         return servletInstance;
     }
 


### PR DESCRIPTION
Without this change the servlet instance will be initialised again when the matcher filter is initialised.