### PR TITLE
Updated embedded Jetty version to 9.4.27.v20200227

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.27.v20200227</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
This is part of a solution towards allowing Spark to serve cookies with the "SameSite" property.

Google Chrome 80, released in February 2020, is now treating the lack of a "SameSite" property in a cookie as equivalent to "SameSite: Lax", instead of "SameSite: None". This breaks functionality in some situations.

A fundamental problem for Java-based web apps is that the Servlet API doesn't yet support the "SameSite" cookie attribute.

Recent Jetty updates have added different workarounds to this problem. By updating the embedded Jetty to 9.4.27, these workarounds become available to Spark apps.
