### PR TITLE
HTTP 2 Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
             <version>${jetty.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
         <!-- JUNIT DEPENDENCY FOR TESTING -->
         <dependency>
             <groupId>junit</groupId>
@@ -121,6 +133,30 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-client</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-conscrypt-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-conscrypt-client</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-http-client-transport</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -16,18 +16,8 @@
  */
 package spark;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServers;
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerClassWrapper;
@@ -39,6 +29,15 @@ import spark.route.ServletRoutes;
 import spark.ssl.SslStores;
 import spark.staticfiles.MimeType;
 import spark.staticfiles.StaticFilesConfiguration;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static spark.globalstate.ServletFlag.isRunningFromServlet;
@@ -62,6 +61,7 @@ public final class Service extends Routable {
 
     protected int port = SPARK_DEFAULT_PORT;
     protected String ipAddress = "0.0.0.0";
+    protected boolean http2Enabled = false;
 
     protected SslStores sslStores;
 
@@ -128,6 +128,19 @@ public final class Service extends Routable {
         }
         this.ipAddress = ipAddress;
 
+        return this;
+    }
+
+    /**
+     * Enables HTTP 2
+     *
+     * @return the object with HTTP 2 enabled
+     */
+    public synchronized Service http2() {
+        if (initialized) {
+            throwBeforeRouteMappingException();
+        }
+        this.http2Enabled = true;
         return this;
     }
 
@@ -577,7 +590,8 @@ public final class Service extends Routable {
                             sslStores,
                             maxThreads,
                             minThreads,
-                            threadIdleTimeoutMillis);
+                            threadIdleTimeoutMillis,
+                            http2Enabled);
                   } catch (Exception e) {
                     initExceptionHandler.accept(e);
                   }

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -953,6 +953,13 @@ public class Spark {
     }
 
     /**
+     * Enables HTTP 2
+     */
+    public static void http2() {
+        getInstance().http2();
+    }
+
+    /**
      * Set the default response transformer. All requests not using a custom transformer will use this one
      *
      * @param transformer

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -16,11 +16,11 @@
  */
 package spark.embeddedserver;
 
-import java.util.Map;
-import java.util.Optional;
-
 import spark.embeddedserver.jetty.websocket.WebSocketHandlerWrapper;
 import spark.ssl.SslStores;
+
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represents an embedded server that can be used in Spark. (this is currently Jetty by default).
@@ -37,6 +37,7 @@ public interface EmbeddedServer {
      * @param maxThreads              - max nbr of threads.
      * @param minThreads              - min nbr of threads.
      * @param threadIdleTimeoutMillis - idle timeout (ms).
+     * @param http2Enabled            - whether http2 is enabled or not.
      * @return The port number the server was launched on.
      */
     int ignite(String host,
@@ -44,7 +45,8 @@ public interface EmbeddedServer {
                SslStores sslStores,
                int maxThreads,
                int minThreads,
-               int threadIdleTimeoutMillis) throws Exception;
+               int threadIdleTimeoutMillis,
+               boolean http2Enabled) throws Exception;
 
     /**
      * Configures the web sockets for the embedded server.

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -16,17 +16,23 @@
  */
 package spark.embeddedserver.jetty;
 
-import java.util.concurrent.TimeUnit;
-
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http2.HTTP2Cipher;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.NegotiatingServerConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-
 import spark.ssl.SslStores;
 import spark.utils.Assert;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Creates socket connectors.
@@ -45,7 +51,8 @@ public class SocketConnectorFactory {
         Assert.notNull(server, "'server' must not be null");
         Assert.notNull(host, "'host' must not be null");
 
-        HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
+        HttpConfiguration httpConfiguration = createHttpConfiguration();
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfiguration);
         ServerConnector connector = new ServerConnector(server, httpConnectionFactory);
         initializeConnector(connector, host, port);
         return connector;
@@ -69,7 +76,93 @@ public class SocketConnectorFactory {
         Assert.notNull(host, "'host' must not be null");
         Assert.notNull(sslStores, "'sslStores' must not be null");
 
-        SslContextFactory sslContextFactory = new SslContextFactory(sslStores.keystoreFile());
+        SslContextFactory sslContextFactory = createSslContextFactory(sslStores);
+
+        HttpConfiguration httpConfiguration = createHttpConfiguration();
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfiguration);
+
+        ServerConnector connector = new ServerConnector(server, sslContextFactory, httpConnectionFactory);
+        initializeConnector(connector, host, port);
+        return connector;
+    }
+
+    /**
+     * Creates an ordinary, non-secured Jetty http2 server.
+     *
+     * @param server Jetty server
+     * @param host   host
+     * @param port   port
+     * @return - a server jetty
+     */
+    public static ServerConnector createHttp2SocketConnector(Server server, String host, int port) {
+        Assert.notNull(server, "'server' must not be null");
+        Assert.notNull(host, "'host' must not be null");
+
+        HttpConfiguration httpConfiguration = createHttpConfiguration();
+
+        HttpConnectionFactory http1 = new HttpConnectionFactory(httpConfiguration);
+        HTTP2CServerConnectionFactory http2c = new HTTP2CServerConnectionFactory(httpConfiguration);
+
+        ServerConnector connector = new ServerConnector(server, http1, http2c);
+        initializeConnector(connector, host, port);
+        return connector;
+    }
+
+    /**
+     * Creates a ssl http2 jetty socket jetty. Keystore required, truststore
+     * optional. If truststore not specified keystore will be reused.
+     *
+     * @param server    Jetty server
+     * @param sslStores the security sslStores.
+     * @param host      host
+     * @param port      port
+     * @return a ssl socket jetty
+     */
+    public static ServerConnector createSecureHttp2SocketConnector(Server server,
+                                                                   String host,
+                                                                   int port,
+                                                                   SslStores sslStores) {
+        Assert.notNull(server, "'server' must not be null");
+        Assert.notNull(host, "'host' must not be null");
+        Assert.notNull(sslStores, "'sslStores' must not be null");
+
+        SslContextFactory sslContextFactory = createSslContextFactory(sslStores);
+        sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
+        sslContextFactory.setUseCipherSuitesOrder(true);
+
+        HttpConfiguration httpConfiguration = createHttpConfiguration();
+
+        HttpConnectionFactory http1 = new HttpConnectionFactory(httpConfiguration);
+        HTTP2ServerConnectionFactory http2 = new HTTP2ServerConnectionFactory(httpConfiguration);
+        NegotiatingServerConnectionFactory alpn = new ALPNServerConnectionFactory();
+        alpn.setDefaultProtocol(http1.getProtocol());
+
+        SslConnectionFactory ssl = new SslConnectionFactory(sslContextFactory, alpn.getProtocol());
+
+        ServerConnector connector = new ServerConnector(server, ssl, alpn, http2, http1);
+        initializeConnector(connector, host, port);
+        return connector;
+    }
+
+    private static void initializeConnector(ServerConnector connector, String host, int port) {
+        // Set some timeout options to make debugging easier.
+        connector.setIdleTimeout(TimeUnit.HOURS.toMillis(1));
+        connector.setHost(host);
+        connector.setPort(port);
+    }
+
+    private static HttpConfiguration createHttpConfiguration() {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setSecureScheme("https");
+        httpConfig.addCustomizer(new SecureRequestCustomizer());
+        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        return httpConfig;
+    }
+
+    private static SslContextFactory createSslContextFactory(SslStores sslStores) {
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+
+        sslContextFactory.setKeyStorePath(sslStores.keystoreFile());
 
         if (sslStores.keystorePassword() != null) {
             sslContextFactory.setKeyStorePassword(sslStores.keystorePassword());
@@ -92,25 +185,7 @@ public class SocketConnectorFactory {
             sslContextFactory.setWantClientAuth(true);
         }
 
-        HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
-
-        ServerConnector connector = new ServerConnector(server, sslContextFactory, httpConnectionFactory);
-        initializeConnector(connector, host, port);
-        return connector;
-    }
-
-    private static void initializeConnector(ServerConnector connector, String host, int port) {
-        // Set some timeout options to make debugging easier.
-        connector.setIdleTimeout(TimeUnit.HOURS.toMillis(1));
-        connector.setHost(host);
-        connector.setPort(port);
-    }
-
-    private static HttpConnectionFactory createHttpConnectionFactory() {
-        HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.setSecureScheme("https");
-        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
-        return new HttpConnectionFactory(httpConfig);
+        return sslContextFactory;
     }
 
 }

--- a/src/test/java/spark/GenericHttp1IntegrationTest.java
+++ b/src/test/java/spark/GenericHttp1IntegrationTest.java
@@ -1,0 +1,35 @@
+package spark;
+
+import org.junit.BeforeClass;
+import spark.util.SparkTestUtil.UrlResponse;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class GenericHttp1IntegrationTest extends GenericIntegrationTest {
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        GenericIntegrationTest.setup();
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod, String path, String body, String acceptType) throws Exception {
+        return testUtil.doMethod(requestMethod, path, body, acceptType);
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod, String path, String body) throws Exception {
+        return testUtil.doMethod(requestMethod, path, body);
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod,
+                         String path,
+                         String body,
+                         boolean secureConnection,
+                         String acceptType,
+                         Map<String, String> reqHeaders) throws Exception {
+        return testUtil.doMethod(requestMethod, path, body, secureConnection, acceptType, reqHeaders);
+    }
+}

--- a/src/test/java/spark/GenericHttp2IntegrationTest.java
+++ b/src/test/java/spark/GenericHttp2IntegrationTest.java
@@ -1,0 +1,46 @@
+package spark;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil.UrlResponse;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class GenericHttp2IntegrationTest extends GenericIntegrationTest {
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        Spark.http2();
+        GenericIntegrationTest.setup();
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod, String path, String body, String acceptType) throws Exception {
+        return testUtil.doHttp2Method(requestMethod, path, body, acceptType);
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod, String path, String body) throws Exception {
+        return testUtil.doHttp2Method(requestMethod, path, body);
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod,
+                         String path,
+                         String body,
+                         boolean secureConnection,
+                         String acceptType,
+                         Map<String, String> reqHeaders) throws Exception {
+        return testUtil.doHttp2Method(requestMethod, path, body, secureConnection, acceptType, reqHeaders);
+    }
+
+    @Test
+    public void testHttp1Request() throws Exception {
+        UrlResponse responseHttp = testUtil.doMethod("GET", "/hi", null);
+        assertEquals(200, responseHttp.status);
+        assertEquals("Hello World!", responseHttp.body);
+    }
+}

--- a/src/test/java/spark/GenericIntegrationTest.java
+++ b/src/test/java/spark/GenericIntegrationTest.java
@@ -1,27 +1,13 @@
 package spark;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.embeddedserver.jetty.websocket.WebSocketTestClient;
 import spark.embeddedserver.jetty.websocket.WebSocketTestHandler;
 import spark.examples.exception.BaseException;
@@ -30,6 +16,19 @@ import spark.examples.exception.NotFoundException;
 import spark.examples.exception.SubclassOfBaseException;
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static spark.Spark.after;
 import static spark.Spark.afterAfter;
@@ -44,14 +43,14 @@ import static spark.Spark.post;
 import static spark.Spark.staticFileLocation;
 import static spark.Spark.webSocket;
 
-public class GenericIntegrationTest {
+public abstract class GenericIntegrationTest {
 
     private static final String NOT_FOUND_BRO = "Not found bro";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GenericIntegrationTest.class);
+    final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
-    static SparkTestUtil testUtil;
-    static File tmpExternalFile;
+    static SparkTestUtil testUtil = new SparkTestUtil(4567);
+    static File tmpExternalFile = new File(System.getProperty("java.io.tmpdir"), "externalFile.html");
 
     @AfterClass
     public static void tearDown() {
@@ -61,12 +60,7 @@ public class GenericIntegrationTest {
         }
     }
 
-    @BeforeClass
     public static void setup() throws IOException {
-        testUtil = new SparkTestUtil(4567);
-
-        tmpExternalFile = new File(System.getProperty("java.io.tmpdir"), "externalFile.html");
-
         FileWriter writer = new FileWriter(tmpExternalFile);
         writer.write("Content of external file");
         writer.flush();
@@ -77,14 +71,17 @@ public class GenericIntegrationTest {
         webSocket("/ws", WebSocketTestHandler.class);
 
         before("/secretcontent/*", (q, a) -> {
+            a.header("WWW-Authenticate", "Bearer");
             halt(401, "Go Away!");
         });
 
         before("/protected/*", "application/xml", (q, a) -> {
+            a.header("WWW-Authenticate", "Bearer");
             halt(401, "Go Away!");
         });
 
         before("/protected/*", "application/json", (q, a) -> {
+            a.header("WWW-Authenticate", "Bearer");
             halt(401, "{\"message\": \"Go Away!\"}");
         });
 
@@ -92,7 +89,7 @@ public class GenericIntegrationTest {
         get("/hi", (q, a) -> "Hello World!");
         get("/binaryhi", (q, a) -> "Hello World!".getBytes());
         get("/bytebufferhi", (q, a) -> ByteBuffer.wrap("Hello World!".getBytes()));
-        get("/inputstreamhi", (q, a) -> new ByteArrayInputStream("Hello World!".getBytes("utf-8")));
+        get("/inputstreamhi", (q, a) -> new ByteArrayInputStream("Hello World!".getBytes(StandardCharsets.UTF_8)));
         get("/param/:param", (q, a) -> "echo: " + q.params(":param"));
 
         path("/firstPath", () -> {
@@ -100,9 +97,7 @@ public class GenericIntegrationTest {
             get("/test", (q, a) -> "Single path-prefix works");
             path("/secondPath", () -> {
                 get("/test", (q, a) -> "Nested path-prefix works");
-                path("/thirdPath", () -> {
-                    get("/test", (q, a) -> "Very nested path-prefix works");
-                });
+                path("/thirdPath", () -> get("/test", (q, a) -> "Very nested path-prefix works"));
             });
         });
 
@@ -174,17 +169,11 @@ public class GenericIntegrationTest {
             throw new JWGmeligMeylingException();
         });
 
-        exception(JWGmeligMeylingException.class, (meylingException, q, a) -> {
-            a.body(meylingException.trustButVerify());
-        });
+        exception(JWGmeligMeylingException.class, (meylingException, q, a) -> a.body(meylingException.trustButVerify()));
 
-        exception(UnsupportedOperationException.class, (exception, q, a) -> {
-            a.body("Exception handled");
-        });
+        exception(UnsupportedOperationException.class, (exception, q, a) -> a.body("Exception handled"));
 
-        exception(BaseException.class, (exception, q, a) -> {
-            a.body("Exception handled");
-        });
+        exception(BaseException.class, (exception, q, a) -> a.body("Exception handled"));
 
         exception(NotFoundException.class, (exception, q, a) -> {
             a.status(404);
@@ -195,47 +184,48 @@ public class GenericIntegrationTest {
             throw new RuntimeException();
         });
 
-        afterAfter("/exception", (request, response) -> {
-            response.body("done executed for exception");
-        });
+        afterAfter("/exception", (request, response) -> response.body("done executed for exception"));
 
         post("/nice", (request, response) -> "nice response");
 
-        afterAfter("/nice", (request, response) -> {
-            response.header("post-process", "nice done response");
-        });
+        afterAfter("/nice", (request, response) -> response.header("post-process", "nice done response"));
 
-        afterAfter((request, response) -> {
-            response.header("post-process-all", "nice done response after all");
-        });
+        afterAfter((request, response) -> response.header("post-process-all", "nice done response after all"));
 
         Spark.awaitInitialization();
     }
 
+    abstract UrlResponse doMethod(String requestMethod, String path, String body, String acceptType) throws Exception;
+
+    abstract UrlResponse doMethod(String requestMethod, String path, String body) throws Exception;
+
+    abstract UrlResponse doMethod(String requestMethod, String path, String body, boolean secureConnection,
+                                  String acceptType, Map<String, String> reqHeaders) throws Exception;
+
     @Test
     public void filters_should_be_accept_type_aware() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/protected/resource", null, "application/json");
-        Assert.assertTrue(response.status == 401);
+        UrlResponse response = doMethod("GET", "/protected/resource", null, "application/json");
+        Assert.assertEquals(401, response.status);
         Assert.assertEquals("{\"message\": \"Go Away!\"}", response.body);
     }
 
     @Test
     public void routes_should_be_accept_type_aware() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/hi", null, "application/json");
+        UrlResponse response = doMethod("GET", "/hi", null, "application/json");
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("{\"message\": \"Hello World\"}", response.body);
     }
 
     @Test
     public void template_view_should_be_rendered_with_given_model_view_object() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/templateView", null);
+        UrlResponse response = doMethod("GET", "/templateView", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Hello from my view", response.body);
     }
 
     @Test
     public void testGetHi() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/hi", null);
+        UrlResponse response = doMethod("GET", "/hi", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Hello World!", response.body);
     }
@@ -243,7 +233,7 @@ public class GenericIntegrationTest {
     @Test
     public void testGetBinaryHi() {
         try {
-            UrlResponse response = testUtil.doMethod("GET", "/binaryhi", null);
+            UrlResponse response = doMethod("GET", "/binaryhi", null);
             Assert.assertEquals(200, response.status);
             Assert.assertEquals("Hello World!", response.body);
         } catch (Throwable e) {
@@ -254,7 +244,7 @@ public class GenericIntegrationTest {
     @Test
     public void testGetByteBufferHi() {
         try {
-            UrlResponse response = testUtil.doMethod("GET", "/bytebufferhi", null);
+            UrlResponse response = doMethod("GET", "/bytebufferhi", null);
             Assert.assertEquals(200, response.status);
             Assert.assertEquals("Hello World!", response.body);
         } catch (Throwable e) {
@@ -265,7 +255,7 @@ public class GenericIntegrationTest {
     @Test
     public void testGetInputStreamHi() {
         try {
-            UrlResponse response = testUtil.doMethod("GET", "/inputstreamhi", null);
+            UrlResponse response = doMethod("GET", "/inputstreamhi", null);
             Assert.assertEquals(200, response.status);
             Assert.assertEquals("Hello World!", response.body);
         } catch (Throwable e) {
@@ -275,14 +265,14 @@ public class GenericIntegrationTest {
 
     @Test
     public void testHiHead() throws Exception {
-        UrlResponse response = testUtil.doMethod("HEAD", "/hi", null);
+        UrlResponse response = doMethod("HEAD", "/hi", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("", response.body);
     }
 
     @Test
     public void testGetHiAfterFilter() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/hi", null);
+        UrlResponse response = doMethod("GET", "/hi", null);
         Assert.assertTrue(response.headers.get("after").contains("foobar"));
     }
 
@@ -292,37 +282,37 @@ public class GenericIntegrationTest {
         Map<String, String> headers = new HashMap<>();
         headers.put("X-Forwarded-For", xForwardedFor);
 
-        UrlResponse response = testUtil.doMethod("GET", "/ip", null, false, "text/html", headers);
+        UrlResponse response = doMethod("GET", "/ip", null, false, "text/html", headers);
         Assert.assertEquals(xForwardedFor, response.body);
 
-        response = testUtil.doMethod("GET", "/ip", null, false, "text/html", null);
+        response = doMethod("GET", "/ip", null, false, "text/html", null);
         Assert.assertNotEquals(xForwardedFor, response.body);
     }
 
     @Test
     public void testGetRoot() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/", null);
+        UrlResponse response = doMethod("GET", "/", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Hello Root!", response.body);
     }
 
     @Test
     public void testParamAndWild() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/paramandwild/thedude/stuff/andits", null);
+        UrlResponse response = doMethod("GET", "/paramandwild/thedude/stuff/andits", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("paramandwild: thedudeandits", response.body);
     }
 
     @Test
     public void testEchoParam1() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/param/shizzy", null);
+        UrlResponse response = doMethod("GET", "/param/shizzy", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: shizzy", response.body);
     }
 
     @Test
     public void testEchoParam2() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/param/gunit", null);
+        UrlResponse response = doMethod("GET", "/param/gunit", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: gunit", response.body);
     }
@@ -331,7 +321,7 @@ public class GenericIntegrationTest {
     public void testEchoParam3() throws Exception {
         String polyglot = "жξ Ä 聊";
         String encoded = URIUtil.encodePath(polyglot);
-        UrlResponse response = testUtil.doMethod("GET", "/param/" + encoded, null);
+        UrlResponse response = doMethod("GET", "/param/" + encoded, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: " + polyglot, response.body);
     }
@@ -339,7 +329,7 @@ public class GenericIntegrationTest {
     @Test
     public void testPathParamsWithPlusSign() throws Exception {
         String pathParamWithPlusSign = "not+broken+path+param";
-        UrlResponse response = testUtil.doMethod("GET", "/param/" + pathParamWithPlusSign, null);
+        UrlResponse response = doMethod("GET", "/param/" + pathParamWithPlusSign, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: " + pathParamWithPlusSign, response.body);
     }
@@ -348,7 +338,7 @@ public class GenericIntegrationTest {
     public void testParamWithEncodedSlash() throws Exception {
         String polyglot = "te/st";
         String encoded = URLEncoder.encode(polyglot, "UTF-8");
-        UrlResponse response = testUtil.doMethod("GET", "/param/" + encoded, null);
+        UrlResponse response = doMethod("GET", "/param/" + encoded, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: " + polyglot, response.body);
     }
@@ -359,8 +349,8 @@ public class GenericIntegrationTest {
         String encodedParam = URLEncoder.encode(param, "UTF-8");
         String splat = "mah/FRIEND";
         String encodedSplat = URLEncoder.encode(splat, "UTF-8");
-        UrlResponse response = testUtil.doMethod("GET",
-                                                 "/paramandwild/" + encodedParam + "/stuff/" + encodedSplat, null);
+        UrlResponse response = doMethod("GET",
+                                        "/paramandwild/" + encodedParam + "/stuff/" + encodedSplat, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("paramandwild: " + param + splat, response.body);
     }
@@ -368,7 +358,7 @@ public class GenericIntegrationTest {
     @Test
     public void testEchoParamWithUpperCaseInValue() throws Exception {
         final String camelCased = "ThisIsAValueAndSparkShouldRetainItsUpperCasedCharacters";
-        UrlResponse response = testUtil.doMethod("GET", "/param/" + camelCased, null);
+        UrlResponse response = doMethod("GET", "/param/" + camelCased, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: " + camelCased, response.body);
     }
@@ -385,40 +375,38 @@ public class GenericIntegrationTest {
     }
 
     private static void registerEchoRoute(final String routePart) {
-        get("/tworoutes/" + routePart + "/:param", (q, a) -> {
-            return routePart + " route: " + q.params(":param");
-        });
+        get("/tworoutes/" + routePart + "/:param", (q, a) -> routePart + " route: " + q.params(":param"));
     }
 
-    private static void assertEchoRoute(String routePart) throws Exception {
+    private void assertEchoRoute(String routePart) throws Exception {
         final String expected = "expected";
-        UrlResponse response = testUtil.doMethod("GET", "/tworoutes/" + routePart + "/" + expected, null);
+        UrlResponse response = doMethod("GET", "/tworoutes/" + routePart + "/" + expected, null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals(routePart + " route: " + expected, response.body);
     }
 
     @Test
     public void testEchoParamWithMaj() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/paramwithmaj/plop", null);
+        UrlResponse response = doMethod("GET", "/paramwithmaj/plop", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: plop", response.body);
     }
 
     @Test
     public void testUnauthorized() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/secretcontent/whateva", null);
-        Assert.assertTrue(response.status == 401);
+        UrlResponse response = doMethod("GET", "/secretcontent/whateva", null);
+        Assert.assertEquals(401, response.status);
     }
 
     @Test
     public void testNotFound() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/no/resource", null);
-        Assert.assertTrue(response.status == 404);
+        UrlResponse response = doMethod("GET", "/no/resource", null);
+        Assert.assertEquals(404, response.status);
     }
 
     @Test
     public void testPost() throws Exception {
-        UrlResponse response = testUtil.doMethod("POST", "/poster", "Fo shizzy");
+        UrlResponse response = doMethod("POST", "/poster", "Fo shizzy");
         LOGGER.info(response.body);
         Assert.assertEquals(201, response.status);
         Assert.assertTrue(response.body.contains("Fo shizzy"));
@@ -436,7 +424,7 @@ public class GenericIntegrationTest {
 
     @Test
     public void testPatch() throws Exception {
-        UrlResponse response = testUtil.doMethod("PATCH", "/patcher", "Fo shizzy");
+        UrlResponse response = doMethod("PATCH", "/patcher", "Fo shizzy");
         LOGGER.info(response.body);
         Assert.assertEquals(200, response.status);
         Assert.assertTrue(response.body.contains("Fo shizzy"));
@@ -444,48 +432,48 @@ public class GenericIntegrationTest {
 
     @Test
     public void testSessionReset() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/session_reset", null);
+        UrlResponse response = doMethod("GET", "/session_reset", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("22222", response.body);
     }
 
     @Test
     public void testStaticFile() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/css/style.css", null);
+        UrlResponse response = doMethod("GET", "/css/style.css", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Content of css file", response.body);
     }
 
     @Test
     public void testExternalStaticFile() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/externalFile.html", null);
+        UrlResponse response = doMethod("GET", "/externalFile.html", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Content of external file", response.body);
     }
 
     @Test
     public void testExceptionMapper() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/throwexception", null);
+        UrlResponse response = doMethod("GET", "/throwexception", null);
         Assert.assertEquals("Exception handled", response.body);
     }
 
     @Test
     public void testInheritanceExceptionMapper() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/throwsubclassofbaseexception", null);
+        UrlResponse response = doMethod("GET", "/throwsubclassofbaseexception", null);
         Assert.assertEquals("Exception handled", response.body);
     }
 
     @Test
     public void testNotFoundExceptionMapper() throws Exception {
         //        thrownotfound
-        UrlResponse response = testUtil.doMethod("GET", "/thrownotfound", null);
+        UrlResponse response = doMethod("GET", "/thrownotfound", null);
         Assert.assertEquals(NOT_FOUND_BRO, response.body);
         Assert.assertEquals(404, response.status);
     }
 
     @Test
     public void testTypedExceptionMapper() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/throwmeyling", null);
+        UrlResponse response = doMethod("GET", "/throwmeyling", null);
         Assert.assertEquals(new JWGmeligMeylingException().trustButVerify(), response.body);
     }
 
@@ -512,38 +500,38 @@ public class GenericIntegrationTest {
 
     @Test
     public void path_should_prefix_routes() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/firstPath/test", null, "application/json");
-        Assert.assertTrue(response.status == 200);
+        UrlResponse response = doMethod("GET", "/firstPath/test", null, "application/json");
+        Assert.assertEquals(200, response.status);
         Assert.assertEquals("Single path-prefix works", response.body);
         Assert.assertEquals("true", response.headers.get("before-filter-ran"));
     }
 
     @Test
     public void paths_should_be_nestable() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/firstPath/secondPath/test", null, "application/json");
-        Assert.assertTrue(response.status == 200);
+        UrlResponse response = doMethod("GET", "/firstPath/secondPath/test", null, "application/json");
+        Assert.assertEquals(200, response.status);
         Assert.assertEquals("Nested path-prefix works", response.body);
         Assert.assertEquals("true", response.headers.get("before-filter-ran"));
     }
 
     @Test
     public void paths_should_be_very_nestable() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/firstPath/secondPath/thirdPath/test", null, "application/json");
-        Assert.assertTrue(response.status == 200);
+        UrlResponse response = doMethod("GET", "/firstPath/secondPath/thirdPath/test", null, "application/json");
+        Assert.assertEquals(200, response.status);
         Assert.assertEquals("Very nested path-prefix works", response.body);
         Assert.assertEquals("true", response.headers.get("before-filter-ran"));
     }
 
     @Test
     public void testRuntimeExceptionForDone() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/exception", null);
+        UrlResponse response = doMethod("GET", "/exception", null);
         Assert.assertEquals("done executed for exception", response.body);
         Assert.assertEquals(500, response.status);
     }
 
     @Test
     public void testRuntimeExceptionForAllRoutesFinally() throws Exception {
-        UrlResponse response = testUtil.doMethod("GET", "/hi", null);
+        UrlResponse response = doMethod("GET", "/hi", null);
         Assert.assertEquals("foobar", response.headers.get("after"));
         Assert.assertEquals("nice done response after all", response.headers.get("post-process-all"));
         Assert.assertEquals(200, response.status);
@@ -551,7 +539,7 @@ public class GenericIntegrationTest {
 
     @Test
     public void testPostProcessBodyForFinally() throws Exception {
-        UrlResponse response = testUtil.doMethod("POST", "/nice", "");
+        UrlResponse response = doMethod("POST", "/nice", "");
         Assert.assertEquals("nice response", response.body);
         Assert.assertEquals("nice done response", response.headers.get("post-process"));
         Assert.assertEquals(200, response.status);

--- a/src/test/java/spark/GenericSecureHttp1IntegrationTest.java
+++ b/src/test/java/spark/GenericSecureHttp1IntegrationTest.java
@@ -1,0 +1,29 @@
+package spark;
+
+import org.junit.BeforeClass;
+import spark.util.SparkTestUtil.UrlResponse;
+
+import java.util.Map;
+
+public class GenericSecureHttp1IntegrationTest extends GenericSecureIntegrationTest {
+
+    @BeforeClass
+    public static void setup() {
+        GenericSecureIntegrationTest.setup();
+    }
+
+    @Override
+    UrlResponse doMethodSecure(String requestMethod, String path, String body) throws Exception {
+        return testUtil.doMethodSecure(requestMethod, path, body);
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod,
+                         String path,
+                         String body,
+                         boolean secureConnection,
+                         String acceptType,
+                         Map<String, String> reqHeaders) throws Exception {
+        return testUtil.doMethod(requestMethod, path, body, secureConnection, acceptType, reqHeaders);
+    }
+}

--- a/src/test/java/spark/GenericSecureHttp2IntegrationTest.java
+++ b/src/test/java/spark/GenericSecureHttp2IntegrationTest.java
@@ -1,0 +1,43 @@
+package spark;
+
+import org.conscrypt.OpenSSLProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import spark.util.SparkTestUtil.UrlResponse;
+
+import java.security.Security;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class GenericSecureHttp2IntegrationTest extends GenericSecureIntegrationTest {
+
+    @BeforeClass
+    public static void setup() {
+        Security.insertProviderAt(new OpenSSLProvider(), 1);
+        Spark.http2();
+        GenericSecureIntegrationTest.setup();
+    }
+
+    @Override
+    UrlResponse doMethodSecure(String requestMethod, String path, String body) throws Exception {
+        return testUtil.doHttp2MethodSecure(requestMethod, path, body);
+    }
+
+    @Override
+    UrlResponse doMethod(String requestMethod,
+                         String path,
+                         String body,
+                         boolean secureConnection,
+                         String acceptType,
+                         Map<String, String> reqHeaders) throws Exception {
+        return testUtil.doHttp2Method(requestMethod, path, body, secureConnection, acceptType, reqHeaders);
+    }
+
+    @Test
+    public void testHttp1Request() throws Exception {
+        UrlResponse responseHttp = testUtil.doMethodSecure("GET", "/hi", null);
+        assertEquals(200, responseHttp.status);
+        assertEquals("Hello World!", responseHttp.body);
+    }
+}

--- a/src/test/java/spark/GenericSecureIntegrationTest.java
+++ b/src/test/java/spark/GenericSecureIntegrationTest.java
@@ -1,17 +1,15 @@
 package spark;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.util.SparkTestUtil;
 import spark.util.SparkTestUtil.UrlResponse;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static spark.Spark.after;
 import static spark.Spark.before;
@@ -20,21 +18,18 @@ import static spark.Spark.halt;
 import static spark.Spark.patch;
 import static spark.Spark.post;
 
-public class GenericSecureIntegrationTest {
+public abstract class GenericSecureIntegrationTest {
 
-    static SparkTestUtil testUtil;
+    static SparkTestUtil testUtil = new SparkTestUtil(4567);
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GenericSecureIntegrationTest.class);
+    final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
     @AfterClass
     public static void tearDown() {
         Spark.stop();
     }
 
-    @BeforeClass
     public static void setup() {
-        testUtil = new SparkTestUtil(4567);
-
         // note that the keystore stuff is retrieved from SparkTestUtil which
         // respects JVM params for keystore, password
         // but offers a default included store if not.
@@ -42,6 +37,7 @@ public class GenericSecureIntegrationTest {
                      SparkTestUtil.getKeystorePassword(), null, null);
 
         before("/protected/*", (request, response) -> {
+            response.header("WWW-Authenticate", "Bearer");
             halt(401, "Go Away!");
         });
 
@@ -67,16 +63,19 @@ public class GenericSecureIntegrationTest {
             return "Body was: " + body;
         });
 
-        after("/hi", (request, response) -> {
-            response.header("after", "foobar");
-        });
+        after("/hi", (request, response) -> response.header("after", "foobar"));
 
         Spark.awaitInitialization();
     }
 
+    abstract UrlResponse doMethodSecure(String requestMethod, String path, String body) throws Exception;
+
+    abstract UrlResponse doMethod(String requestMethod, String path, String body, boolean secureConnection,
+                                  String acceptType, Map<String, String> reqHeaders) throws Exception;
+
     @Test
     public void testGetHi() throws Exception {
-        SparkTestUtil.UrlResponse response = testUtil.doMethodSecure("GET", "/hi", null);
+        SparkTestUtil.UrlResponse response = doMethodSecure("GET", "/hi", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Hello World!", response.body);
     }
@@ -87,69 +86,69 @@ public class GenericSecureIntegrationTest {
         Map<String, String> headers = new HashMap<>();
         headers.put("X-Forwarded-For", xForwardedFor);
 
-        UrlResponse response = testUtil.doMethod("GET", "/ip", null, true, "text/html", headers);
+        UrlResponse response = doMethod("GET", "/ip", null, true, "text/html", headers);
         Assert.assertEquals(xForwardedFor, response.body);
 
-        response = testUtil.doMethod("GET", "/ip", null, true, "text/html", null);
+        response = doMethod("GET", "/ip", null, true, "text/html", null);
         Assert.assertNotEquals(xForwardedFor, response.body);
     }
 
     @Test
     public void testHiHead() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("HEAD", "/hi", null);
+        UrlResponse response = doMethodSecure("HEAD", "/hi", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("", response.body);
     }
 
     @Test
     public void testGetHiAfterFilter() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("GET", "/hi", null);
+        UrlResponse response = doMethodSecure("GET", "/hi", null);
         Assert.assertTrue(response.headers.get("after").contains("foobar"));
     }
 
     @Test
     public void testGetRoot() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("GET", "/", null);
+        UrlResponse response = doMethodSecure("GET", "/", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("Hello Root!", response.body);
     }
 
     @Test
     public void testEchoParam1() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("GET", "/shizzy", null);
+        UrlResponse response = doMethodSecure("GET", "/shizzy", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: shizzy", response.body);
     }
 
     @Test
     public void testEchoParam2() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("GET", "/gunit", null);
+        UrlResponse response = doMethodSecure("GET", "/gunit", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: gunit", response.body);
     }
 
     @Test
     public void testEchoParamWithMaj() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("GET", "/paramwithmaj/plop", null);
+        UrlResponse response = doMethodSecure("GET", "/paramwithmaj/plop", null);
         Assert.assertEquals(200, response.status);
         Assert.assertEquals("echo: plop", response.body);
     }
 
     @Test
     public void testUnauthorized() throws Exception {
-        UrlResponse urlResponse = testUtil.doMethodSecure("GET", "/protected/resource", null);
-        Assert.assertTrue(urlResponse.status == 401);
+        UrlResponse urlResponse = doMethodSecure("GET", "/protected/resource", null);
+        Assert.assertEquals(401, urlResponse.status);
     }
 
     @Test
     public void testNotFound() throws Exception {
-        UrlResponse urlResponse = testUtil.doMethodSecure("GET", "/no/resource", null);
-        Assert.assertTrue(urlResponse.status == 404);
+        UrlResponse urlResponse = doMethodSecure("GET", "/no/resource", null);
+        Assert.assertEquals(404, urlResponse.status);
     }
 
     @Test
     public void testPost() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("POST", "/poster", "Fo shizzy");
+        UrlResponse response = doMethodSecure("POST", "/poster", "Fo shizzy");
         LOGGER.info(response.body);
         Assert.assertEquals(201, response.status);
         Assert.assertTrue(response.body.contains("Fo shizzy"));
@@ -157,7 +156,7 @@ public class GenericSecureIntegrationTest {
 
     @Test
     public void testPatch() throws Exception {
-        UrlResponse response = testUtil.doMethodSecure("PATCH", "/patcher", "Fo shizzy");
+        UrlResponse response = doMethodSecure("PATCH", "/patcher", "Fo shizzy");
         LOGGER.info(response.body);
         Assert.assertEquals(200, response.status);
         Assert.assertTrue(response.body.contains("Fo shizzy"));

--- a/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
+++ b/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
@@ -1,19 +1,17 @@
 package spark.embeddedserver;
 
-import java.io.File;
-
 import org.eclipse.jetty.server.NCSARequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.junit.AfterClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
 import spark.Spark;
 import spark.embeddedserver.jetty.EmbeddedJettyFactory;
 import spark.embeddedserver.jetty.JettyServerFactory;
+
+import java.io.File;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -42,7 +40,7 @@ public class EmbeddedServersTest {
         EmbeddedServers.add(id, new EmbeddedJettyFactory(serverFactory));
         EmbeddedServer embeddedServer = EmbeddedServers.create(id, null, null, null, false);
         assertNotNull(embeddedServer);
-        embeddedServer.ignite("localhost", 0, null, 0, 0, 0);
+        embeddedServer.ignite("localhost", 0, null, 0, 0, 0, false);
 
         assertTrue(requestLogFile.exists());
         embeddedServer.extinguish();

--- a/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
@@ -3,8 +3,8 @@ package spark.embeddedserver.jetty;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-
 import spark.ExceptionMapper;
 import spark.embeddedserver.EmbeddedServer;
 import spark.route.Routes;
@@ -21,23 +21,32 @@ import static org.mockito.Mockito.when;
 public class EmbeddedJettyFactoryTest {
 
     private EmbeddedServer embeddedServer;
+    private JettyServerFactory jettyServerFactory;
+    private StaticFilesConfiguration staticFilesConfiguration;
+    private ExceptionMapper exceptionMapper;
+    private Routes routes;
+    private Server server;
+
+    @Before
+    public void setUpMocks() {
+        jettyServerFactory = mock(JettyServerFactory.class);
+        staticFilesConfiguration = mock(StaticFilesConfiguration.class);
+        exceptionMapper = mock(ExceptionMapper.class);
+        routes = mock(Routes.class);
+        server = new Server();
+        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
+    }
 
     @Test
     public void create() throws Exception {
-        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
-        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
-        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
-        final Routes routes = mock(Routes.class);
-
-        Server server = new Server();
-        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
-
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
 
-        embeddedServer.ignite("localhost", 6757, null, 100, 10, 10000);
+        igniteServer(embeddedServer, false);
+        embeddedServer.extinguish();
+        igniteServer(embeddedServer, true);
 
-        verify(jettyServerFactory, times(1)).create(100, 10, 10000);
+        verify(jettyServerFactory, times(2)).create(100, 10, 10000);
         verifyNoMoreInteractions(jettyServerFactory);
         assertTrue(((JettyHandler) server.getHandler()).getSessionCookieConfig().isHttpOnly());
     }
@@ -45,52 +54,41 @@ public class EmbeddedJettyFactoryTest {
     @Test
     public void create_withThreadPool() throws Exception {
         final QueuedThreadPool threadPool = new QueuedThreadPool(100);
-        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
-        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
-        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
-        final Routes routes = mock(Routes.class);
 
         when(jettyServerFactory.create(threadPool)).thenReturn(new Server(threadPool));
 
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withThreadPool(threadPool);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
 
-        embeddedServer.ignite("localhost", 6758, null, 0, 0, 0);
+        igniteServer(embeddedServer, false);
+        embeddedServer.extinguish();
+        igniteServer(embeddedServer, true);
 
-        verify(jettyServerFactory, times(1)).create(threadPool);
+        verify(jettyServerFactory, times(2)).create(threadPool);
         verifyNoMoreInteractions(jettyServerFactory);
     }
 
     @Test
     public void create_withNullThreadPool() throws Exception {
-        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
-        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
-        final ExceptionMapper exceptionMapper = mock(ExceptionMapper.class);
-        final Routes routes = mock(Routes.class);
-
-        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(new Server());
-
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withThreadPool(null);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
 
-        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000);
+        igniteServer(embeddedServer, false);
+        embeddedServer.extinguish();
+        igniteServer(embeddedServer, true);
 
-        verify(jettyServerFactory, times(1)).create(100, 10, 10000);
+        verify(jettyServerFactory, times(2)).create(100, 10, 10000);
         verifyNoMoreInteractions(jettyServerFactory);
     }
 
     @Test
     public void create_withoutHttpOnly() throws Exception {
-        final JettyServerFactory jettyServerFactory = mock(JettyServerFactory.class);
-        final StaticFilesConfiguration staticFilesConfiguration = mock(StaticFilesConfiguration.class);
-        final Routes routes = mock(Routes.class);
-
-        Server server = new Server();
-        when(jettyServerFactory.create(100, 10, 10000)).thenReturn(server);
-
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withHttpOnly(false);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, false);
-        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000);
+
+        igniteServer(embeddedServer, false);
+        embeddedServer.extinguish();
+        igniteServer(embeddedServer, true);
 
         assertFalse(((JettyHandler) server.getHandler()).getSessionCookieConfig().isHttpOnly());
     }
@@ -100,5 +98,9 @@ public class EmbeddedJettyFactoryTest {
         if (embeddedServer != null) {
             embeddedServer.extinguish();
         }
+    }
+
+    private void igniteServer(EmbeddedServer embeddedServer, boolean http2Enabled) throws Exception {
+        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000, http2Enabled);
     }
 }

--- a/src/test/java/spark/embeddedserver/jetty/SocketConnectorFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/SocketConnectorFactoryTest.java
@@ -12,7 +12,9 @@ import spark.ssl.SslStores;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SocketConnectorFactoryTest {
 
@@ -27,6 +29,17 @@ public class SocketConnectorFactoryTest {
         }
     }
 
+    @Test
+    public void testCreateHttp2SocketConnector_whenServerIsNull_thenThrowException() {
+
+        try {
+            SocketConnectorFactory.createHttp2SocketConnector(null, "host", 80);
+            fail("SocketConnector creation should have thrown an IllegalArgumentException");
+        } catch(IllegalArgumentException ex) {
+            assertEquals("'server' must not be null", ex.getMessage());
+        }
+    }
+
 
     @Test
     public void testCreateSocketConnector_whenHostIsNull_thenThrowException() {
@@ -35,6 +48,19 @@ public class SocketConnectorFactoryTest {
 
         try {
             SocketConnectorFactory.createSocketConnector(server, null, 80);
+            fail("SocketConnector creation should have thrown an IllegalArgumentException");
+        } catch(IllegalArgumentException ex) {
+            assertEquals("'host' must not be null", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateHttp2SocketConnector_whenHostIsNull_thenThrowException() {
+
+        Server server = new Server();
+
+        try {
+            SocketConnectorFactory.createHttp2SocketConnector(server, null, 80);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'host' must not be null", ex.getMessage());
@@ -60,10 +86,39 @@ public class SocketConnectorFactoryTest {
     }
 
     @Test
+    public void testCreateHttp2SocketConnector() {
+
+        final String host = "localhost";
+        final int port = 8888;
+
+        Server server = new Server();
+        ServerConnector serverConnector = SocketConnectorFactory.createHttp2SocketConnector(server, "localhost", 8888);
+
+        String internalHost = Whitebox.getInternalState(serverConnector, "_host");
+        int internalPort = Whitebox.getInternalState(serverConnector, "_port");
+        Server internalServerConnector = Whitebox.getInternalState(serverConnector, "_server");
+
+        assertEquals("Server Connector Host should be set to the specified server", host, internalHost);
+        assertEquals("Server Connector Port should be set to the specified port", port, internalPort);
+        assertEquals("Server Connector Server should be set to the specified server", internalServerConnector, server);
+    }
+
+    @Test
     public void testCreateSecureSocketConnector_whenServerIsNull() {
 
         try {
             SocketConnectorFactory.createSecureSocketConnector(null, "localhost", 80, null);
+            fail("SocketConnector creation should have thrown an IllegalArgumentException");
+        } catch(IllegalArgumentException ex) {
+            assertEquals("'server' must not be null", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateSecureHttp2SocketConnector_whenServerIsNull() {
+
+        try {
+            SocketConnectorFactory.createSecureHttp2SocketConnector(null, "localhost", 80, null);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'server' must not be null", ex.getMessage());
@@ -84,12 +139,38 @@ public class SocketConnectorFactoryTest {
     }
 
     @Test
+    public void testCreateSecureHttp2SocketConnector_whenHostIsNull() {
+
+        Server server = new Server();
+
+        try {
+            SocketConnectorFactory.createSecureSocketConnector(server, null, 80, null);
+            fail("SocketConnector creation should have thrown an IllegalArgumentException");
+        } catch(IllegalArgumentException ex) {
+            assertEquals("'host' must not be null", ex.getMessage());
+        }
+    }
+
+    @Test
     public void testCreateSecureSocketConnector_whenSslStoresIsNull() {
 
         Server server = new Server();
 
         try {
             SocketConnectorFactory.createSecureSocketConnector(server, "localhost", 80, null);
+            fail("SocketConnector creation should have thrown an IllegalArgumentException");
+        } catch(IllegalArgumentException ex) {
+            assertEquals("'sslStores' must not be null", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateSecureHttp2SocketConnector_whenSslStoresIsNull() {
+
+        Server server = new Server();
+
+        try {
+            SocketConnectorFactory.createSecureHttp2SocketConnector(server, "localhost", 80, null);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'sslStores' must not be null", ex.getMessage());
@@ -134,6 +215,46 @@ public class SocketConnectorFactoryTest {
 
         assertEquals("Should return the Truststore file specified", truststoreFile,
                 sslContextFactory.getTrustStoreResource().getFile().getName());
+
+    }
+
+    @Test
+    @PrepareForTest({ServerConnector.class})
+    public void testCreateSecureHttp2SocketConnector() throws  Exception {
+
+        final String host = "localhost";
+        final int port = 8888;
+
+        final String keystoreFile = "keystoreFile.jks";
+        final String keystorePassword = "keystorePassword";
+        final String truststoreFile = "truststoreFile.jks";
+        final String trustStorePassword = "trustStorePassword";
+
+        SslStores sslStores = SslStores.create(keystoreFile, keystorePassword, truststoreFile, trustStorePassword);
+
+        Server server = new Server();
+
+        ServerConnector serverConnector = SocketConnectorFactory.createSecureHttp2SocketConnector(server, host, port, sslStores);
+
+        String internalHost = Whitebox.getInternalState(serverConnector, "_host");
+        int internalPort = Whitebox.getInternalState(serverConnector, "_port");
+
+        assertEquals("Server Connector Host should be set to the specified server", host, internalHost);
+        assertEquals("Server Connector Port should be set to the specified port", port, internalPort);
+
+        Map<String, ConnectionFactory> factories = Whitebox.getInternalState(serverConnector, "_factories");
+
+        assertTrue("Should return true because factory for SSL should have been set",
+                   factories.containsKey("ssl") && factories.get("ssl") != null);
+
+        SslConnectionFactory sslConnectionFactory = (SslConnectionFactory) factories.get("ssl");
+        SslContextFactory sslContextFactory = sslConnectionFactory.getSslContextFactory();
+
+        assertEquals("Should return the Keystore file specified", keystoreFile,
+                     sslContextFactory.getKeyStoreResource().getFile().getName());
+
+        assertEquals("Should return the Truststore file specified", truststoreFile,
+                     sslContextFactory.getTrustStoreResource().getFile().getName());
 
     }
 

--- a/src/test/java/spark/examples/hello/HelloHttp2World.java
+++ b/src/test/java/spark/examples/hello/HelloHttp2World.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2011- Per Wendel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.examples.hello;
+
+import static spark.Spark.get;
+import static spark.Spark.http2;
+
+/**
+ * This will start a server with HTTP 1.1 and HTTP2 clear
+ * By default it will do HTTP 1.1 but you can upgrade for HTTP 2
+ * or use HTTP 2 directly.
+ * To test the upgrade you can run: "nghttp -vu http://127.0.0.1:8080/hello"
+ * To test the direct use of http2: "nghttp -v http://127.0.0.1:8080/hello"
+ **/
+ public class HelloHttp2World {
+
+    public static void main(String[] args) {
+        http2();
+        get("/hello", (request, response) -> "Hello World!");
+    }
+}

--- a/src/test/java/spark/examples/hello/HelloSecureHttp2World.java
+++ b/src/test/java/spark/examples/hello/HelloSecureHttp2World.java
@@ -1,0 +1,26 @@
+package spark.examples.hello;
+
+import static spark.Spark.get;
+import static spark.Spark.http2;
+import static spark.Spark.secure;
+
+/**
+ * You'll need to provide a JKS keystore as arg 0 and its password as arg 1.
+ * And also to add a ALPN server implementation to your maven/gradle config:
+ * jetty-alpn-openjdk8-server for JDK 8
+ * jetty-alpn-java-server for JDK >= 9
+ * jetty-alpn-conscrypt-server for native SSL implementation (JDK >= 8)
+ * If using Conscrypt you will also need to add the following line before
+ * enabling http2: "Security.insertProviderAt(new OpenSSLProvider(), 1);"
+ * Docs for the ALPN are available at:
+ * https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html
+ */
+public class HelloSecureHttp2World {
+    public static void main(String[] args) {
+        secure(args[0], args[1], null, null);
+        http2();
+        get("/hello", (request, response) -> {
+            return "Hello Secure World!";
+        });
+    }
+}

--- a/src/test/java/spark/util/SparkTestUtil.java
+++ b/src/test/java/spark/util/SparkTestUtil.java
@@ -1,19 +1,5 @@
 package spark.util;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.security.KeyStore;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
@@ -40,6 +26,29 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.KeyStore;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
 
 public class SparkTestUtil {
 
@@ -136,6 +145,105 @@ public class SparkTestUtil {
         return urlResponse;
     }
 
+    public UrlResponse doHttp2Method(String requestMethod, String path, String body)
+        throws Exception {
+        return doHttp2Method(requestMethod, path, body, false, "text/html", null);
+    }
+
+    public UrlResponse doHttp2Method(String requestMethod, String path, String body, String acceptType)
+        throws Exception {
+        return doHttp2Method(requestMethod, path, body, false, acceptType, null);
+    }
+
+    public UrlResponse doHttp2MethodSecure(String requestMethod, String path, String body)
+        throws Exception {
+        return doHttp2Method(requestMethod, path, body, true, "text/html", null);
+    }
+
+    public UrlResponse doHttp2Method(String requestMethod, String path, String body, boolean secureConnection,
+                                     String acceptType, Map<String, String> reqHeaders) throws Exception {
+        org.eclipse.jetty.client.HttpClient http2Client = null;
+        try {
+            http2Client = getHttp2Client();
+            http2Client.start();
+            Request http2Request = getHttp2Request(http2Client, requestMethod, path, body, secureConnection, acceptType, reqHeaders);
+            ContentResponse response = http2Request.send();
+
+            UrlResponse urlResponse = new UrlResponse();
+            urlResponse.status = response.getStatus();
+
+            if (response.getContent() != null) {
+                urlResponse.body = response.getContentAsString();
+            } else {
+                urlResponse.body = "";
+            }
+            Map<String, String> headers = new HashMap<>();
+            HttpFields allHeaders = response.getHeaders();
+            for (HttpField header : allHeaders) {
+                headers.put(header.getName(), header.getValue());
+            }
+            urlResponse.headers = headers;
+
+            return urlResponse;
+        } finally {
+            if (http2Client != null) {
+                try {
+                    http2Client.stop();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    private org.eclipse.jetty.client.HttpClient getHttp2Client() {
+        HTTP2Client http2Client = new HTTP2Client();
+
+        SslContextFactory sslContextFactory = new SslContextFactory.Client();
+        sslContextFactory.setEndpointIdentificationAlgorithm("");
+
+        sslContextFactory.setTrustStorePath(getTrustStoreLocation());
+        sslContextFactory.setTrustStorePassword(getTrustStorePassword());
+
+        return new org.eclipse.jetty.client.HttpClient(
+            new HttpClientTransportOverHTTP2(http2Client), sslContextFactory);
+    }
+
+    private Request getHttp2Request(org.eclipse.jetty.client.HttpClient httpClient,
+                                    String requestMethod,
+                                    String path,
+                                    String body,
+                                    boolean secureConnection,
+                                    String acceptType,
+                                    Map<String, String> reqHeaders) {
+            String protocol = secureConnection ? "https" : "http";
+            String uri = protocol + "://localhost:" + port + path;
+
+            Request request = httpClient.newRequest(uri);
+            request.version(HTTP_2);
+            addHeaders(reqHeaders, request);
+            request.method(requestMethod);
+
+            switch (requestMethod) {
+                case "GET":
+                case "DELETE":
+                    request.header("Accept", acceptType);
+                    return request;
+                case "HEAD":
+                case "TRACE":
+                case "OPTIONS":
+                case "LOCK":
+                    return request;
+                case "POST":
+                case "PATCH":
+                case "PUT":
+                    request.header("Accept", acceptType);
+                    request.content(new StringContentProvider(body));
+                    return request;
+                default:
+                    throw new IllegalArgumentException("Unknown method " + requestMethod);
+            }
+    }
+
     private HttpUriRequest getHttpRequest(String requestMethod, String path, String body, boolean secureConnection,
                                           String acceptType, Map<String, String> reqHeaders) {
         try {
@@ -215,6 +323,14 @@ public class SparkTestUtil {
         if (reqHeaders != null) {
             for (Map.Entry<String, String> header : reqHeaders.entrySet()) {
                 req.addHeader(header.getKey(), header.getValue());
+            }
+        }
+    }
+
+    private void addHeaders(Map<String, String> reqHeaders, Request req) {
+        if (reqHeaders != null) {
+            for (Map.Entry<String, String> header : reqHeaders.entrySet()) {
+                req.header(header.getKey(), header.getValue());
             }
         }
     }


### PR DESCRIPTION
Picked up where https://github.com/perwendel/spark/pull/514 started, updated the code so it works with the current Jetty version being used and added. Added tests, one http2 client using Jetty and also support for HTTP 2 clear protocol so people can also leverage HTTP 2 benefits (GRPC for instance - https://grpc.io/blog/grpc-with-json/) when not using SSL.

People can also test it using [JitPack](https://jitpack.io/#luneo7/spark/http2-SNAPSHOT) 