### PR TITLE
Add methods for removing routes at runtime

### DIFF
--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -864,6 +864,33 @@ public class Spark {
         getInstance().patch(path, acceptType, route, transformer);
     }
 
+    /**
+     * Removes a particular route from the collection of those that have been previously routed.
+     * Search for previously established routes using the given path and removes any matches that are found.
+     *
+     * @param path          the route path
+     * @return              <tt>true</tt> if this is a matching route which has been previously routed
+     * @throws IllegalArgumentException if <tt>path</tt> is null or blank
+     */
+    public static boolean removeRoute(String path) {
+        return getInstance().routes.remove(path);
+    }
+
+    /**
+     * Removes a particular route from the collection of those that have been previously routed.
+     * Search for previously established routes using the given path and HTTP method, removing any
+     * matches that are found.
+     *
+     * @param path          the route path
+     * @param httpMethod    the http method
+     * @return <tt>true</tt> if this is a matching route that has been previously routed
+     * @throws IllegalArgumentException if <tt>path</tt> is null or blank or if <tt>httpMethod</tt> is null, blank,
+     * or an invalid HTTP method
+     */
+    public static boolean removeRoute(String path, String httpMethod) {
+        return getInstance().routes.remove(path, httpMethod);
+    }
+
     //////////////////////////////////////////////////
     // END Response Transforming Routes
     //////////////////////////////////////////////////

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -865,20 +865,20 @@ public class Spark {
     }
 
     /**
-     * Removes a particular route from the collection of those that have been previously routed.
-     * Search for previously established routes using the given path and removes any matches that are found.
+     * Unmaps a particular route from the collection of those that have been previously routed.
+     * Search for previously established routes using the given path and unmaps any matches that are found.
      *
      * @param path          the route path
      * @return              <tt>true</tt> if this is a matching route which has been previously routed
      * @throws IllegalArgumentException if <tt>path</tt> is null or blank
      */
-    public static boolean removeRoute(String path) {
+    public static boolean unmap(String path) {
         return getInstance().routes.remove(path);
     }
 
     /**
-     * Removes a particular route from the collection of those that have been previously routed.
-     * Search for previously established routes using the given path and HTTP method, removing any
+     * Unmaps a particular route from the collection of those that have been previously routed.
+     * Search for previously established routes using the given path and HTTP method, unmaps any
      * matches that are found.
      *
      * @param path          the route path
@@ -887,7 +887,7 @@ public class Spark {
      * @throws IllegalArgumentException if <tt>path</tt> is null or blank or if <tt>httpMethod</tt> is null, blank,
      * or an invalid HTTP method
      */
-    public static boolean removeRoute(String path, String httpMethod) {
+    public static boolean unmap(String path, String httpMethod) {
         return getInstance().routes.remove(path, httpMethod);
     }
 


### PR DESCRIPTION
Currently spark doesn't provide for a way to remove routes after they have already been registered. Several users on both StackOverflow and other forums asked how to access this functionality. My patch exposes two static methods in `spark.Spark`, one for removing a route based on the URL path, and another for removing a route based on the URL path and `HttpMethod`.

Removing routes at runtime could be useful if the developer wants to, for example, change the logic of a route at runtime, then redeploy. I personally use a forked and patched version of Spark with the ability to remove routes in maintaining a web-based API management system that lets users define logic through a web interface.