### PR TITLE
added trustForwardHeaders method to decide if to trust HTTP forward headers

### DIFF
--- a/src/main/java/spark/Service.java
+++ b/src/main/java/spark/Service.java
@@ -95,6 +95,8 @@ public final class Service extends Routable {
         System.exit(100);
     };
 
+    private boolean trustForwardHeaders = true;
+
     /**
      * Creates a new Service (a Spark instance). This should be used instead of the static API if the user wants
      * multiple services in one process.
@@ -635,7 +637,8 @@ public final class Service extends Routable {
                             sslStores,
                             maxThreads,
                             minThreads,
-                            threadIdleTimeoutMillis);
+                            threadIdleTimeoutMillis,
+                            trustForwardHeaders);
                   } catch (Exception e) {
                     initExceptionHandler.accept(e);
                   }
@@ -742,6 +745,21 @@ public final class Service extends Routable {
      */
     public HaltException halt(int status, String body) {
         throw new HaltException(status, body);
+    }
+
+    /**
+     * Set whether Spark should trust the HTTP headers that are commonly used in reverse proxies.
+     * More info at https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/ForwardedRequestCustomizer.html
+     *
+     * @param
+     */
+    public synchronized Service trustForwardHeaders(boolean trustForwardHeaders) {
+        if (initialized) {
+            throwBeforeRouteMappingException();
+        }
+        this.trustForwardHeaders = trustForwardHeaders;
+
+        return this;
     }
 
     /**

--- a/src/main/java/spark/Spark.java
+++ b/src/main/java/spark/Spark.java
@@ -1277,6 +1277,17 @@ public class Spark {
         getInstance().internalServerError(route);
     }
 
+    ////////////////
+    // Security //
+
+    /**
+     * Whether to trust Forwarded, X-Forwarded-Host, X-Forwarded-Server, X-Forwarded-For, X-Forwarded-Proto, X-Proxied-Https headers
+     * as defined at https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/ForwardedRequestCustomizer.html
+     */
+    public static void trustForwardHeaders(boolean trustForwardHeaders) {
+        getInstance().trustForwardHeaders(trustForwardHeaders);
+    }
+
     /**
      * Initializes the Spark server. SHOULD just be used when using the Websockets functionality.
      */

--- a/src/main/java/spark/embeddedserver/EmbeddedServer.java
+++ b/src/main/java/spark/embeddedserver/EmbeddedServer.java
@@ -44,7 +44,8 @@ public interface EmbeddedServer {
                SslStores sslStores,
                int maxThreads,
                int minThreads,
-               int threadIdleTimeoutMillis) throws Exception;
+               int threadIdleTimeoutMillis,
+               boolean trustForwardHeaders) throws Exception;
 
     /**
      * Configures the web sockets for the embedded server.

--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -82,7 +82,8 @@ public class EmbeddedJettyServer implements EmbeddedServer {
                       SslStores sslStores,
                       int maxThreads,
                       int minThreads,
-                      int threadIdleTimeoutMillis) throws Exception {
+                      int threadIdleTimeoutMillis,
+                      boolean trustForwardHeaders) throws Exception {
 
         boolean hasCustomizedConnectors = false;
 
@@ -105,9 +106,9 @@ public class EmbeddedJettyServer implements EmbeddedServer {
         ServerConnector connector;
 
         if (sslStores == null) {
-            connector = SocketConnectorFactory.createSocketConnector(server, host, port);
+            connector = SocketConnectorFactory.createSocketConnector(server, host, port, trustForwardHeaders);
         } else {
-            connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores);
+            connector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores, trustForwardHeaders);
         }
 
         Connector previousConnectors[] = server.getConnectors();

--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -41,11 +41,11 @@ public class SocketConnectorFactory {
      * @param port   port
      * @return - a server jetty
      */
-    public static ServerConnector createSocketConnector(Server server, String host, int port) {
+    public static ServerConnector createSocketConnector(Server server, String host, int port, boolean trustForwardHeaders) {
         Assert.notNull(server, "'server' must not be null");
         Assert.notNull(host, "'host' must not be null");
 
-        HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
+        HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory(trustForwardHeaders);
         ServerConnector connector = new ServerConnector(server, httpConnectionFactory);
         initializeConnector(connector, host, port);
         return connector;
@@ -64,7 +64,8 @@ public class SocketConnectorFactory {
     public static ServerConnector createSecureSocketConnector(Server server,
                                                               String host,
                                                               int port,
-                                                              SslStores sslStores) {
+                                                              SslStores sslStores,
+                                                              boolean trustForwardHeaders) {
         Assert.notNull(server, "'server' must not be null");
         Assert.notNull(host, "'host' must not be null");
         Assert.notNull(sslStores, "'sslStores' must not be null");
@@ -93,7 +94,7 @@ public class SocketConnectorFactory {
             sslContextFactory.setWantClientAuth(true);
         }
 
-        HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory();
+        HttpConnectionFactory httpConnectionFactory = createHttpConnectionFactory(trustForwardHeaders);
 
         ServerConnector connector = new ServerConnector(server, sslContextFactory, httpConnectionFactory);
         initializeConnector(connector, host, port);
@@ -107,10 +108,11 @@ public class SocketConnectorFactory {
         connector.setPort(port);
     }
 
-    private static HttpConnectionFactory createHttpConnectionFactory() {
+    private static HttpConnectionFactory createHttpConnectionFactory(boolean trustForwardHeaders) {
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.setSecureScheme("https");
-        httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        if(trustForwardHeaders)
+            httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         return new HttpConnectionFactory(httpConfig);
     }
 

--- a/src/test/java/spark/GenericSecureIntegrationTest.java
+++ b/src/test/java/spark/GenericSecureIntegrationTest.java
@@ -94,6 +94,7 @@ public class GenericSecureIntegrationTest {
         Assert.assertNotEquals(xForwardedFor, response.body);
     }
 
+
     @Test
     public void testHiHead() throws Exception {
         UrlResponse response = testUtil.doMethodSecure("HEAD", "/hi", null);

--- a/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
+++ b/src/test/java/spark/embeddedserver/EmbeddedServersTest.java
@@ -42,7 +42,7 @@ public class EmbeddedServersTest {
         EmbeddedServers.add(id, new EmbeddedJettyFactory(serverFactory));
         EmbeddedServer embeddedServer = EmbeddedServers.create(id, null, null, null, false);
         assertNotNull(embeddedServer);
-        embeddedServer.ignite("localhost", 0, null, 0, 0, 0);
+        embeddedServer.ignite("localhost", 0, null, 0, 0, 0, true);
 
         assertTrue(requestLogFile.exists());
         embeddedServer.extinguish();

--- a/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/EmbeddedJettyFactoryTest.java
@@ -35,7 +35,7 @@ public class EmbeddedJettyFactoryTest {
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
 
-        embeddedServer.ignite("localhost", 6757, null, 100, 10, 10000);
+        embeddedServer.ignite("localhost", 6757, null, 100, 10, 10000, true);
 
         verify(jettyServerFactory, times(1)).create(100, 10, 10000);
         verifyNoMoreInteractions(jettyServerFactory);
@@ -55,7 +55,7 @@ public class EmbeddedJettyFactoryTest {
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withThreadPool(threadPool);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
 
-        embeddedServer.ignite("localhost", 6758, null, 0, 0, 0);
+        embeddedServer.ignite("localhost", 6758, null, 0, 0, 0, true);
 
         verify(jettyServerFactory, times(1)).create(threadPool);
         verifyNoMoreInteractions(jettyServerFactory);
@@ -73,7 +73,7 @@ public class EmbeddedJettyFactoryTest {
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withThreadPool(null);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, exceptionMapper, false);
 
-        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000);
+        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000, true);
 
         verify(jettyServerFactory, times(1)).create(100, 10, 10000);
         verifyNoMoreInteractions(jettyServerFactory);
@@ -90,7 +90,7 @@ public class EmbeddedJettyFactoryTest {
 
         final EmbeddedJettyFactory embeddedJettyFactory = new EmbeddedJettyFactory(jettyServerFactory).withHttpOnly(false);
         embeddedServer = embeddedJettyFactory.create(routes, staticFilesConfiguration, false);
-        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000);
+        embeddedServer.ignite("localhost", 6759, null, 100, 10, 10000, true);
 
         assertFalse(((JettyHandler) server.getHandler()).getSessionCookieConfig().isHttpOnly());
     }

--- a/src/test/java/spark/embeddedserver/jetty/SocketConnectorFactoryTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/SocketConnectorFactoryTest.java
@@ -20,7 +20,7 @@ public class SocketConnectorFactoryTest {
     public void testCreateSocketConnector_whenServerIsNull_thenThrowException() {
 
         try {
-            SocketConnectorFactory.createSocketConnector(null, "host", 80);
+            SocketConnectorFactory.createSocketConnector(null, "host", 80, true);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'server' must not be null", ex.getMessage());
@@ -34,7 +34,7 @@ public class SocketConnectorFactoryTest {
         Server server = new Server();
 
         try {
-            SocketConnectorFactory.createSocketConnector(server, null, 80);
+            SocketConnectorFactory.createSocketConnector(server, null, 80, true);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'host' must not be null", ex.getMessage());
@@ -48,7 +48,7 @@ public class SocketConnectorFactoryTest {
         final int port = 8888;
 
         Server server = new Server();
-        ServerConnector serverConnector = SocketConnectorFactory.createSocketConnector(server, "localhost", 8888);
+        ServerConnector serverConnector = SocketConnectorFactory.createSocketConnector(server, "localhost", 8888, true);
 
         String internalHost = Whitebox.getInternalState(serverConnector, "_host");
         int internalPort = Whitebox.getInternalState(serverConnector, "_port");
@@ -63,7 +63,7 @@ public class SocketConnectorFactoryTest {
     public void testCreateSecureSocketConnector_whenServerIsNull() {
 
         try {
-            SocketConnectorFactory.createSecureSocketConnector(null, "localhost", 80, null);
+            SocketConnectorFactory.createSecureSocketConnector(null, "localhost", 80, null, true);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'server' must not be null", ex.getMessage());
@@ -76,7 +76,7 @@ public class SocketConnectorFactoryTest {
         Server server = new Server();
 
         try {
-            SocketConnectorFactory.createSecureSocketConnector(server, null, 80, null);
+            SocketConnectorFactory.createSecureSocketConnector(server, null, 80, null, true);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'host' must not be null", ex.getMessage());
@@ -89,7 +89,7 @@ public class SocketConnectorFactoryTest {
         Server server = new Server();
 
         try {
-            SocketConnectorFactory.createSecureSocketConnector(server, "localhost", 80, null);
+            SocketConnectorFactory.createSecureSocketConnector(server, "localhost", 80, null, true);
             fail("SocketConnector creation should have thrown an IllegalArgumentException");
         } catch(IllegalArgumentException ex) {
             assertEquals("'sslStores' must not be null", ex.getMessage());
@@ -113,7 +113,7 @@ public class SocketConnectorFactoryTest {
 
         Server server = new Server();
 
-        ServerConnector serverConnector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores);
+        ServerConnector serverConnector = SocketConnectorFactory.createSecureSocketConnector(server, host, port, sslStores, true);
 
         String internalHost = Whitebox.getInternalState(serverConnector, "_host");
         int internalPort = Whitebox.getInternalState(serverConnector, "_port");


### PR DESCRIPTION
It seems that from https://github.com/perwendel/spark/issues/320 Spark blindly trusts HTTP headers that can be spoofed, with no way to disable this behavior.

The newly introduced method ```Spark.trustForwardHeaders``` allows you to specify if you want to use jetty's ForwardedRequestCustomizer (https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/ForwardedRequestCustomizer.html)