### PR TITLE
CI build and test Java on Linux and MacOS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,24 @@
+name: Java CI build and test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        java: [1.8]
+      fail-fast: false
+      max-parallel: 2 
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Verify with Maven
+        run: mvn -X verify -B --file pom.xml
+...


### PR DESCRIPTION
Use GitHub CI build and test Spark for Java 8 on Linux and MacOS.

Signed-off-by: Carl Dea <carl.dea@gmail.com>