### PR TITLE
Provide Automatic-Module-Name attribute in MANIFEST.MF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,18 @@
                 <version>3.5.1</version>
                 <extensions>true</extensions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.sparkjava.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This will allow projects following the Java module system to use this library.

Fix issue https://github.com/perwendel/spark/issues/961

```
module my.module.system {
    requires java.sql;
    requires com.com.sparkjava.core;
}
```

More info https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers