### PR TITLE
Disable server version response header

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
+++ b/src/main/java/spark/embeddedserver/jetty/SocketConnectorFactory.java
@@ -111,6 +111,7 @@ public class SocketConnectorFactory {
     private static HttpConnectionFactory createHttpConnectionFactory(boolean trustForwardHeaders) {
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.setSecureScheme("https");
+        httpConfig.setSendServerVersion(false);
         if(trustForwardHeaders)
             httpConfig.addCustomizer(new ForwardedRequestCustomizer());
         return new HttpConnectionFactory(httpConfig);


### PR DESCRIPTION
Per the [OWASP top 10](https://owasp.org/www-project-top-ten/), server information leakage is a no-no.