### PR TITLE
fix issue #318 change HashMap to ConcurrentHashMap

### DIFF
--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -18,6 +18,7 @@ package spark;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ExceptionMapper {
 
@@ -52,7 +53,7 @@ public class ExceptionMapper {
      * Class constructor
      */
     public ExceptionMapper() {
-        this.exceptionMap = new HashMap<>();
+        this.exceptionMap = new ConcurrentHashMap<>();
     }
 
     /**
@@ -94,7 +95,8 @@ public class ExceptionMapper {
 
             // No handler found either for the superclasses of the exception class
             // We cache the null value to prevent future
-            this.exceptionMap.put(exceptionClass, null);
+            // We do not need to cache the null value. comment by lloyd.
+            // this.exceptionMap.put(exceptionClass, null);
             return null;
         }
 


### PR DESCRIPTION
ExceptionMapper is accessed from multiple request threads but the underlying Map is a HashMap; This commit replace HashMap with ConcurrentHashMap which is multi-thread safe.