### PR TITLE
Fix issue 1056 handling the trailing slash

### DIFF
--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -18,6 +18,7 @@ package spark;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ExceptionMapper {
 
@@ -52,7 +53,7 @@ public class ExceptionMapper {
      * Class constructor
      */
     public ExceptionMapper() {
-        this.exceptionMap = new HashMap<>();
+        this.exceptionMap = new ConcurrentHashMap<>();
     }
 
     /**
@@ -94,7 +95,8 @@ public class ExceptionMapper {
 
             // No handler found either for the superclasses of the exception class
             // We cache the null value to prevent future
-            this.exceptionMap.put(exceptionClass, null);
+            // We do not need to cache the null value. comment by lloyd.
+            // this.exceptionMap.put(exceptionClass, null);
             return null;
         }
 

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -105,6 +105,8 @@ public class MatcherFilter implements Filter {
 
         String httpMethodStr = method.toLowerCase();
         String uri = httpRequest.getRequestURI();
+        if (uri.length() > 1 && uri.endsWith("/"))
+            uri = uri.substring(0, uri.length() - 1);
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
         Body body = Body.create();
@@ -133,7 +135,6 @@ public class MatcherFilter implements Filter {
                 BeforeFilters.execute(context);
                 Routes.execute(context);
                 AfterFilters.execute(context);
-
             } catch (HaltException halt) {
 
                 Halt.modify(httpResponse, body, halt);


### PR DESCRIPTION
http://sparkjava.com/documentation#redirects, method doesn't seem to work when I try to add the trailing slash. And  it does not match trailing slashes with a mapped route. So it considers /api/test and /api/test/ as different URIs. This commit solve thoese problem with little change in code. The changed file: src/main/java/spark/http/matching/MatcherFilter.java line 107, add
```java
108 if (uri.length() > 1 && uri.endsWith("/"))
109           uri = uri.substring(0, uri.length() - 1);
```