### PR TITLE
Fix issue 1069 and add according Test

### DIFF
--- a/src/main/java/spark/ExceptionMapper.java
+++ b/src/main/java/spark/ExceptionMapper.java
@@ -18,6 +18,7 @@ package spark;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ExceptionMapper {
 
@@ -52,7 +53,7 @@ public class ExceptionMapper {
      * Class constructor
      */
     public ExceptionMapper() {
-        this.exceptionMap = new HashMap<>();
+        this.exceptionMap = new ConcurrentHashMap<>();
     }
 
     /**
@@ -94,7 +95,8 @@ public class ExceptionMapper {
 
             // No handler found either for the superclasses of the exception class
             // We cache the null value to prevent future
-            this.exceptionMap.put(exceptionClass, null);
+            // We do not need to cache the null value. comment by lloyd.
+            // this.exceptionMap.put(exceptionClass, null);
             return null;
         }
 

--- a/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
+++ b/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
@@ -33,7 +33,7 @@ import org.eclipse.jetty.server.session.SessionHandler;
  */
 public class JettyHandler extends SessionHandler {
 
-    private Filter filter;
+    private final Filter filter;
 
     public JettyHandler(Filter filter) {
         this.filter = filter;
@@ -45,15 +45,10 @@ public class JettyHandler extends SessionHandler {
             Request baseRequest,
             HttpServletRequest request,
             HttpServletResponse response) throws IOException, ServletException {
-
         HttpRequestWrapper wrapper = new HttpRequestWrapper(request);
         filter.doFilter(wrapper, response, null);
 
-        if (wrapper.notConsumed()) {
-            baseRequest.setHandled(false);
-        } else {
-            baseRequest.setHandled(true);
-        }
+        baseRequest.setHandled(!wrapper.notConsumed());
 
     }
 

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -105,6 +105,8 @@ public class MatcherFilter implements Filter {
 
         String httpMethodStr = method.toLowerCase();
         String uri = httpRequest.getRequestURI();
+        if (uri.length() > 1 && uri.endsWith("/"))
+            uri = uri.substring(0, uri.length() - 1);
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
         Body body = Body.create();
@@ -133,7 +135,6 @@ public class MatcherFilter implements Filter {
                 BeforeFilters.execute(context);
                 Routes.execute(context);
                 AfterFilters.execute(context);
-
             } catch (HaltException halt) {
 
                 Halt.modify(httpResponse, body, halt);

--- a/src/test/java/spark/embeddedserver/jetty/JettyHandlerTest.java
+++ b/src/test/java/spark/embeddedserver/jetty/JettyHandlerTest.java
@@ -1,0 +1,4 @@
+package spark.embeddedserver.jetty;
+
+public class JettyHandlerTest {
+}


### PR DESCRIPTION
When I debug the process to reproduce the issue, I find that the `Host` of HttpServletRequest passed in `/src/main/java/spark/embeddedserver/jetty/JettyHandler.doHandle()` method is proxy.mydomain.com, which means it is not a bug in code.
After searching for answear, I find this [link](https://stackoverflow.com/questions/19084340/real-life-usage-of-the-x-forwarded-host-header) may help you understand the problem.
And add a test for request with X-Forwarded-Host.