### PR TITLE
Solve the problem of non-ASCII characters in URL. Try to fix #1026 

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -17,6 +17,7 @@
 package spark.http.matching;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -105,6 +106,7 @@ public class MatcherFilter implements Filter {
 
         String httpMethodStr = method.toLowerCase();
         String uri = httpRequest.getRequestURI();
+        uri = URLDecoder.decode(uri, "UTF-8");
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
         Body body = Body.create();

--- a/src/test/java/spark/Test1026.java
+++ b/src/test/java/spark/Test1026.java
@@ -1,0 +1,33 @@
+package spark;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import spark.util.SparkTestUtil;
+
+import static org.junit.Assert.*;
+import static spark.Spark.*;
+
+// Try to fix issue 1026: https://github.com/perwendel/spark/issues/1026
+// If your path of URL contain this character %, please do not put the URL into address bar in browser directly.
+// Encode the URL with JavaScrip firstly, url_encode = encodeURI(URL)   (JavaScrip language)
+// For example, encodeURI("http://localhost:4567/api/v1/permissionrole/permission/get%2Fabc中文한국어にほんごلغة عربية")
+// Then put the encodeURI into the address bar in browser, you will get correct answer
+
+public class Test1026 {
+    private static final String ROUTE = "/api/v1/permissionrole/permission/get%2Fabc中文한국어にほんごلغة عربية";
+    private static SparkTestUtil http;
+
+    @Before
+    public void setup() {
+        http = new SparkTestUtil(4567);
+        get(ROUTE, (q,a)-> "Get filter matched");
+        awaitInitialization();
+    }
+
+    @Test
+    public void testUrl() throws Exception {
+        SparkTestUtil.UrlResponse response = http.get(ROUTE);
+        assertEquals(200,response.status);
+    }
+}

--- a/src/test/java/spark/util/SparkTestUtil.java
+++ b/src/test/java/spark/util/SparkTestUtil.java
@@ -4,6 +4,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -54,12 +55,12 @@ public class SparkTestUtil {
 
     private HttpClientBuilder httpClientBuilder() {
         SSLConnectionSocketFactory sslConnectionSocketFactory =
-                new SSLConnectionSocketFactory(getSslFactory(), (paramString, paramSSLSession) -> true);
+            new SSLConnectionSocketFactory(getSslFactory(), (paramString, paramSSLSession) -> true);
         Registry<ConnectionSocketFactory> socketRegistry = RegistryBuilder
-                .<ConnectionSocketFactory>create()
-                .register("http", PlainConnectionSocketFactory.INSTANCE)
-                .register("https", sslConnectionSocketFactory)
-                .build();
+            .<ConnectionSocketFactory>create()
+            .register("http", PlainConnectionSocketFactory.INSTANCE)
+            .register("https", sslConnectionSocketFactory)
+            .build();
         BasicHttpClientConnectionManager connManager = new BasicHttpClientConnectionManager(socketRegistry);
         return HttpClientBuilder.create().setConnectionManager(connManager);
     }
@@ -92,7 +93,7 @@ public class SparkTestUtil {
 
 
     public UrlResponse doMethodSecure(String requestMethod, String path, String body)
-            throws Exception {
+        throws Exception {
         return doMethod(requestMethod, path, body, true, "text/html");
     }
 
@@ -101,7 +102,7 @@ public class SparkTestUtil {
     }
 
     public UrlResponse doMethodSecure(String requestMethod, String path, String body, String acceptType)
-            throws Exception {
+        throws Exception {
         return doMethod(requestMethod, path, body, true, acceptType);
     }
 
@@ -140,8 +141,8 @@ public class SparkTestUtil {
                                           String acceptType, Map<String, String> reqHeaders) {
         try {
             String protocol = secureConnection ? "https" : "http";
-            String uri = protocol + "://localhost:" + port + path;
-
+            //String uri = protocol + "://localhost:" + port + path;
+            URI uri = new URI(protocol, "//localhost:" + port + path, null);
             if (requestMethod.equals("GET")) {
                 HttpGet httpGet = new HttpGet(uri);
                 httpGet.setHeader("Accept", acceptType);
@@ -206,7 +207,7 @@ public class SparkTestUtil {
 
             throw new IllegalArgumentException("Unknown method " + requestMethod);
 
-        } catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }
@@ -319,6 +320,11 @@ public class SparkTestUtil {
         public HttpLock(final String uri) {
             super();
             setURI(URI.create(uri));
+        }
+
+        public HttpLock(URI uri) {
+            super();
+            setURI(uri);
         }
 
         @Override


### PR DESCRIPTION
Try to fix #1026
Now URL supports non-ASCII code such as 中文한국어にほんごلغة عربية, which is based on utf8 coding.

If your path of URL contains % or other non-ASCII characters, please do not put the URL into the address bar in the browser directly.

Encode the URL with JavaScrip firstly, url_encode = encodeURI(URL)   (JavaScrip language)

For example, encodeURI("http://localhost:4567/api/v1/permissionrole/permission/get%2Fabc中文한국어にほんごلغة عربية")

Then put the encodeURI into the address bar in the browser, you will get the correct answer.

Co-Authored-By: Chauncey-Xxy <70973261+Chauncey-Xxy@users.noreply.github.com>