### PR TITLE
Fix #1077 : Solve the bad route selection based on acceptType.

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -125,15 +125,15 @@ public class MatcherFilter implements Filter {
         HttpMethod httpMethod = HttpMethod.get(httpMethodStr);
 
         RouteContext context = RouteContext.create()
-            .withMatcher(routeMatcher)
-            .withHttpRequest(httpRequest)
-            .withUri(uri)
-            .withAcceptType(acceptType)
-            .withBody(body)
-            .withRequestWrapper(requestWrapper)
-            .withResponseWrapper(responseWrapper)
-            .withResponse(response)
-            .withHttpMethod(httpMethod);
+                .withMatcher(routeMatcher)
+                .withHttpRequest(httpRequest)
+                .withUri(uri)
+                .withAcceptType(acceptType)
+                .withBody(body)
+                .withRequestWrapper(requestWrapper)
+                .withResponseWrapper(responseWrapper)
+                .withResponse(response)
+                .withHttpMethod(httpMethod);
 
         try {
             try {
@@ -149,13 +149,13 @@ public class MatcherFilter implements Filter {
             } catch (Exception generalException) {
 
                 GeneralError.modify(
-                    httpRequest,
-                    httpResponse,
-                    body,
-                    requestWrapper,
-                    responseWrapper,
-                    exceptionMapper,
-                    generalException);
+                        httpRequest,
+                        httpResponse,
+                        body,
+                        requestWrapper,
+                        responseWrapper,
+                        exceptionMapper,
+                        generalException);
 
             }
 
@@ -173,7 +173,7 @@ public class MatcherFilter implements Filter {
 
             if (body.notSet()) {
                 LOG.info("The requested route [{}] has not been mapped in Spark for {}: [{}]",
-                    uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
+                         uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
                 if (CustomErrorPages.existsFor(404)) {
@@ -189,13 +189,13 @@ public class MatcherFilter implements Filter {
                 AfterAfterFilters.execute(context);
             } catch (Exception generalException) {
                 GeneralError.modify(
-                    httpRequest,
-                    httpResponse,
-                    body,
-                    requestWrapper,
-                    responseWrapper,
-                    exceptionMapper,
-                    generalException);
+                        httpRequest,
+                        httpResponse,
+                        body,
+                        requestWrapper,
+                        responseWrapper,
+                        exceptionMapper,
+                        generalException);
             }
         }
 

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -17,6 +17,7 @@
 package spark.http.matching;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -34,6 +35,7 @@ import spark.RequestResponseFactory;
 import spark.Response;
 import spark.embeddedserver.jetty.HttpRequestWrapper;
 import spark.route.HttpMethod;
+import spark.routematch.RouteMatch;
 import spark.serialization.SerializerChain;
 import spark.staticfiles.StaticFilesConfiguration;
 
@@ -107,6 +109,12 @@ public class MatcherFilter implements Filter {
         String uri = httpRequest.getRequestURI();
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
+        List<RouteMatch> routes=routeMatcher.findAll();
+        String firstAcceptType=routes.get(0).getAcceptType();
+        if(acceptType.equals("*/*")){
+            acceptType=firstAcceptType;
+        }
+
         Body body = Body.create();
 
         RequestWrapper requestWrapper = RequestWrapper.create();
@@ -117,15 +125,15 @@ public class MatcherFilter implements Filter {
         HttpMethod httpMethod = HttpMethod.get(httpMethodStr);
 
         RouteContext context = RouteContext.create()
-                .withMatcher(routeMatcher)
-                .withHttpRequest(httpRequest)
-                .withUri(uri)
-                .withAcceptType(acceptType)
-                .withBody(body)
-                .withRequestWrapper(requestWrapper)
-                .withResponseWrapper(responseWrapper)
-                .withResponse(response)
-                .withHttpMethod(httpMethod);
+            .withMatcher(routeMatcher)
+            .withHttpRequest(httpRequest)
+            .withUri(uri)
+            .withAcceptType(acceptType)
+            .withBody(body)
+            .withRequestWrapper(requestWrapper)
+            .withResponseWrapper(responseWrapper)
+            .withResponse(response)
+            .withHttpMethod(httpMethod);
 
         try {
             try {
@@ -141,13 +149,13 @@ public class MatcherFilter implements Filter {
             } catch (Exception generalException) {
 
                 GeneralError.modify(
-                        httpRequest,
-                        httpResponse,
-                        body,
-                        requestWrapper,
-                        responseWrapper,
-                        exceptionMapper,
-                        generalException);
+                    httpRequest,
+                    httpResponse,
+                    body,
+                    requestWrapper,
+                    responseWrapper,
+                    exceptionMapper,
+                    generalException);
 
             }
 
@@ -165,7 +173,7 @@ public class MatcherFilter implements Filter {
 
             if (body.notSet()) {
                 LOG.info("The requested route [{}] has not been mapped in Spark for {}: [{}]",
-                         uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
+                    uri, ACCEPT_TYPE_REQUEST_MIME_HEADER, acceptType);
                 httpResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
                 if (CustomErrorPages.existsFor(404)) {
@@ -181,13 +189,13 @@ public class MatcherFilter implements Filter {
                 AfterAfterFilters.execute(context);
             } catch (Exception generalException) {
                 GeneralError.modify(
-                        httpRequest,
-                        httpResponse,
-                        body,
-                        requestWrapper,
-                        responseWrapper,
-                        exceptionMapper,
-                        generalException);
+                    httpRequest,
+                    httpResponse,
+                    body,
+                    requestWrapper,
+                    responseWrapper,
+                    exceptionMapper,
+                    generalException);
             }
         }
 

--- a/src/test/java/spark/Issue1077Test.java
+++ b/src/test/java/spark/Issue1077Test.java
@@ -1,0 +1,29 @@
+package spark;
+
+import static spark.Spark.*;
+
+
+// Try to fix issue 1026: https://github.com/perwendel/spark/issues/1077
+// I am not sure whether it is a bug, because it is tagged as Bug ..?
+// But I think it conflict with the documentation, so I try to fix it
+// In short, we expect the input and output are:
+// curl -i -H "Accept: application/json" http://localhost:4567/hello : Hello application json
+// curl -i -H "Accept: text/html" http://localhost:4567/hello : Go Away!!!
+// curl http://localhost:4567/hello : Hello application json
+// The first and second are right, but now the last command will get output: Go Away!!!
+// I think it is not reasonable because the empty acceptType should match every possibilities
+// so with the earliest match, it should match the first possible acceptTyoe
+// Therefore, you can exchange the 20th and 22th line to check whether it match the first type
+
+public class Issue1077Test {
+    public static void main(String[] args) {
+        get("/hello","application/json", (request, response) -> "{\"message\": \"Hello application json\"}");
+
+        get("/hello","text/json", (request, response) -> "{\"message\": \"Hello text json\"}");
+
+        get("/hello", (request, response) -> {
+            response.status(406);
+            return "Go Away!!!";
+        });
+    }
+}

--- a/src/test/java/spark/Issue1077Test.java
+++ b/src/test/java/spark/Issue1077Test.java
@@ -12,7 +12,7 @@ import static spark.Spark.*;
 // curl http://localhost:4567/hello : Hello application json
 // The first and second are right, but now the last command will get output: Go Away!!!
 // I think it is not reasonable because the empty acceptType should match every possibilities
-// so with the earliest match, it should match the first possible acceptTyoe
+// so with the earliest match, it should match the first possible acceptType
 // Therefore, you can exchange the 20th and 22th line to check whether it match the first type
 
 public class Issue1077Test {


### PR DESCRIPTION
Try to fix #1077
I am not sure whether it is a bug, because it is tagged as Bug ..?, but I think it conflict with the documentation, so I try to fix it.

In short, we expect the input with empty acceptType will match any possible types as follows:
 curl -i -H "Accept: application/json" http://localhost:4567/hello : Hello application json
 curl -i -H "Accept: text/html" http://localhost:4567/hello : Go Away!!!
 curl http://localhost:4567/hello : Hello application json
Now the first and second are right, but the last command will get output: Go Away!!!
I think it is not reasonable because the empty acceptType should match every possibilities and use the earliest match principle, it should match the first possible acceptType.
So I change the codes to match "*/*" with the earliest acceptType.

Co-Authored-By: Bugjudger https://github.com/Bugjudger