### PR TITLE
Fix #1077 : Solve the bad route selection based on acceptType

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -17,6 +17,7 @@
 package spark.http.matching;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -34,6 +35,7 @@ import spark.RequestResponseFactory;
 import spark.Response;
 import spark.embeddedserver.jetty.HttpRequestWrapper;
 import spark.route.HttpMethod;
+import spark.routematch.RouteMatch;
 import spark.serialization.SerializerChain;
 import spark.staticfiles.StaticFilesConfiguration;
 
@@ -106,6 +108,12 @@ public class MatcherFilter implements Filter {
         String httpMethodStr = method.toLowerCase();
         String uri = httpRequest.getRequestURI();
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
+
+        List<RouteMatch> routes=routeMatcher.findAll();
+        String firstAcceptType=routes.get(0).getAcceptType();
+        if(acceptType.equals("*/*")){
+            acceptType=firstAcceptType;
+        }
 
         Body body = Body.create();
 

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -110,8 +110,14 @@ public class MatcherFilter implements Filter {
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
         List<RouteMatch> routes=routeMatcher.findAll();
-        String firstAcceptType=routes.get(0).getAcceptType();
-        if(acceptType.equals("*/*")){
+        String firstAcceptType=null;
+        for (RouteMatch rm:routes) {
+            if(rm.getMatchUri().equals(uri)){
+                firstAcceptType=rm.getAcceptType();
+                break;
+            }
+        }
+        if(acceptType.equals("*/*")&&firstAcceptType!=null){
             acceptType=firstAcceptType;
         }
 

--- a/src/test/java/spark/Issue1077Test.java
+++ b/src/test/java/spark/Issue1077Test.java
@@ -1,0 +1,29 @@
+package spark;
+
+import static spark.Spark.*;
+
+
+// Try to fix issue 1026: https://github.com/perwendel/spark/issues/1077
+// I am not sure whether it is a bug, because it is tagged as Bug ..?
+// But I think it conflict with the documentation, so I try to fix it
+// In short, we expect the input and output are:
+// curl -i -H "Accept: application/json" http://localhost:4567/hello : Hello application json
+// curl -i -H "Accept: text/html" http://localhost:4567/hello : Go Away!!!
+// curl http://localhost:4567/hello : Hello application json
+// The first and second are right, but now the last command will get output: Go Away!!!
+// I think it is not reasonable because the empty acceptType should match every possibilities
+// so with the earliest match, it should match the first possible acceptType
+// Therefore, you can exchange the 20th and 22th line to check whether it match the first type
+
+public class Issue1077Test {
+    public static void main(String[] args) {
+        get("/hello","application/json", (request, response) -> "{\"message\": \"Hello application json\"}");
+
+        get("/hello","text/json", (request, response) -> "{\"message\": \"Hello text json\"}");
+
+        get("/hello", (request, response) -> {
+            response.status(406);
+            return "Go Away!!!";
+        });
+    }
+}

--- a/src/test/java/spark/Issue1077Test.java
+++ b/src/test/java/spark/Issue1077Test.java
@@ -1,9 +1,15 @@
 package spark;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import spark.util.SparkTestUtil;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 import static spark.Spark.*;
 
-
-// Try to fix issue 1026: https://github.com/perwendel/spark/issues/1077
 // I am not sure whether it is a bug, because it is tagged as Bug ..?
 // But I think it conflict with the documentation, so I try to fix it
 // In short, we expect the input and output are:
@@ -13,17 +19,87 @@ import static spark.Spark.*;
 // The first and second are right, but now the last command will get output: Go Away!!!
 // I think it is not reasonable because the empty acceptType should match every possibilities
 // so with the earliest match, it should match the first possible acceptType
-// Therefore, you can exchange the 20th and 22th line to check whether it match the first type
+// TestWheteherMatchRight() checks whether it matchs right
+// TestWhetherMatchFirst() checks whether it matchs first
 
 public class Issue1077Test {
-    public static void main(String[] args) {
-        get("/hello","application/json", (request, response) -> "{\"message\": \"Hello application json\"}");
 
-        get("/hello","text/json", (request, response) -> "{\"message\": \"Hello text json\"}");
+    public static final String HELLO = "/hello";
 
-        get("/hello", (request, response) -> {
+    public static final String TEST="/test";
+
+    public static final int PORT = 4567;
+
+    private static SparkTestUtil http;
+
+    @Before
+    public void setup() {
+        http = new SparkTestUtil(PORT);
+
+        get(HELLO,"application/json", (request, response) -> "Hello application json");
+
+        get(HELLO,"text/json", (request, response) -> "Hello text json");
+
+        get(HELLO, (request, response) -> {
             response.status(406);
             return "Go Away!!!";
         });
+
+        get(TEST,"text/json", (request, response) -> "Hello text json");
+
+        get(TEST,"application/json", (request, response) -> "Hello application json");
+
+        get(TEST, (request, response) -> {
+            response.status(406);
+            return "Go Away!!!";
+        });
+    }
+
+    // Try to fix issue 1077: https://github.com/perwendel/spark/issues/1077
+    @Test
+    public void TestWheteherMatchRight() {
+
+        try {
+            Map<String, String> requestHeader = new HashMap<>();
+            requestHeader.put("Host", "localhost:" + PORT);
+            requestHeader.put("User-Agent", "curl/7.55.1");
+            requestHeader.put("x-forwarded-host", "proxy.mydomain.com");
+
+            SparkTestUtil.UrlResponse response = http.doMethod("GET",HELLO, "", false, "*/*", requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Hello application json", response.body);
+
+            response = http.doMethod("GET",HELLO, "", false, "text/json", requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Hello text json", response.body);
+
+            response = http.doMethod("GET",HELLO, "", false, "text/html*", requestHeader);
+            assertEquals(406, response.status);
+            assertEquals("Go Away!!!", response.body);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Try to fix issue 1077: https://github.com/perwendel/spark/issues/1077
+    @Test
+    public void TestWhetherMatchFirst() {
+        try {
+            Map<String, String> requestHeader = new HashMap<>();
+            requestHeader.put("Host", "localhost:" + PORT);
+            requestHeader.put("User-Agent", "curl/7.55.1");
+            requestHeader.put("x-forwarded-host", "proxy.mydomain.com");
+
+            SparkTestUtil.UrlResponse response = http.doMethod("GET",TEST, "", false, "*/*", requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Hello text json", response.body);
+
+            response = http.doMethod("GET",HELLO, "", false, "*/*", requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Hello application json", response.body);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
Try to fix #1077
I am not sure whether it is a bug, because it is tagged as Bug ..?, but I think it conflict with the documentation, so I try to fix it.

In short, we expect the input with empty acceptType will match any possible types as follows:
curl -i -H "Accept: application/json" http://localhost:4567/hello : Hello application json
curl -i -H "Accept: text/html" http://localhost:4567/hello : Go Away!!!
curl http://localhost:4567/hello : Hello application json
Now the first and second are right, but the last command will get output: Go Away!!!
I think it is not reasonable because the empty acceptType should match every possibilities and use the earliest match principle, it should match the first possible acceptType.
So I change the codes to match "/" with the earliest acceptType.

Co-Authored-By: Bugjudger <56737316+bugjudger@users.noreply.github.com>