### PR TITLE
Fix #688: Priority of accept types is incorrect if the client specifies no q factor

### DIFF
--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -107,7 +107,7 @@ public class MatcherFilter implements Filter {
         String uri = httpRequest.getRequestURI();
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
-        if(!acceptType.contains(";q=") && acceptType.endsWith("*/*")){
+        if(acceptType!=null&&!acceptType.contains(";q=") && acceptType.endsWith("*/*")){
             //It is from IE
             acceptType=acceptType.substring(0,acceptType.indexOf(", */*"))+";q=0.9,*/*;q=0.8";
         }

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -107,6 +107,11 @@ public class MatcherFilter implements Filter {
         String uri = httpRequest.getRequestURI();
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
+        if(!acceptType.contains(";q=") && acceptType.endsWith("*/*")){
+            //It is from IE
+            acceptType=acceptType.substring(0,acceptType.indexOf(", */*"))+";q=0.9,*/*;q=0.8";
+        }
+
         Body body = Body.create();
 
         RequestWrapper requestWrapper = RequestWrapper.create();

--- a/src/main/java/spark/http/matching/MatcherFilter.java
+++ b/src/main/java/spark/http/matching/MatcherFilter.java
@@ -107,7 +107,7 @@ public class MatcherFilter implements Filter {
         String uri = httpRequest.getRequestURI();
         String acceptType = httpRequest.getHeader(ACCEPT_TYPE_REQUEST_MIME_HEADER);
 
-        if(acceptType!=null&&!acceptType.contains(";q=") && acceptType.endsWith("*/*")){
+        if(acceptType!=null&&!acceptType.trim().equals("*/*")&&!acceptType.contains(";q=") && acceptType.endsWith("*/*")){
             //It is from IE
             acceptType=acceptType.substring(0,acceptType.indexOf(", */*"))+";q=0.9,*/*;q=0.8";
         }

--- a/src/test/java/spark/Issue688Test.java
+++ b/src/test/java/spark/Issue688Test.java
@@ -1,0 +1,63 @@
+package spark;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import spark.util.SparkTestUtil;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static spark.Spark.*;
+
+// When IE broswer visit spark, there are some problems
+// It is because IE will not contains q in AcceptType
+// So the chosen route doesn't fit the design documentation as follows
+
+public class Issue688Test {
+
+    public static final String HELLO = "/hello";
+
+    public static final String TEST="/test";
+
+    public static final int PORT = 4567;
+
+    private static SparkTestUtil http;
+
+    @Before
+    public void setup() {
+        http = new SparkTestUtil(PORT);
+
+        get(HELLO, (request, response) -> "Abstract");
+
+        get(HELLO,"text/html", (request, response) -> "Specific");
+    }
+
+    // Try to fix issue 688: https://github.com/perwendel/spark/issues/688
+    @Test
+    public void TestWheteherMatchRight() {
+
+        try {
+            Map<String, String> requestHeader = new HashMap<>();
+            requestHeader.put("Host", "localhost:" + PORT);
+            requestHeader.put("User-Agent", "curl/7.55.1");
+            requestHeader.put("x-forwarded-host", "proxy.mydomain.com");
+
+            String acceptTypeIE="text/html, application/xhtml+xml, image/jxr, */*";
+            String acceptTypeChrome="text/html,application/xhtml+xml,application/xml;q=0.9," +
+                "image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9\n";
+
+            SparkTestUtil.UrlResponse response = http.doMethod("GET",HELLO, "", false, acceptTypeIE, requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Specific", response.body);
+
+            response = http.doMethod("GET",HELLO, "", false, acceptTypeChrome, requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Specific", response.body);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/test/java/spark/Issue688Test.java
+++ b/src/test/java/spark/Issue688Test.java
@@ -33,6 +33,7 @@ public class Issue688Test {
         get(HELLO,"text/html", (request, response) -> "Specific");
     }
 
+
     // Try to fix issue 688: https://github.com/perwendel/spark/issues/688
     @Test
     public void TestWheteherMatchRight() {
@@ -46,6 +47,8 @@ public class Issue688Test {
             String acceptTypeIE="text/html, application/xhtml+xml, image/jxr, */*";
             String acceptTypeChrome="text/html,application/xhtml+xml,application/xml;q=0.9," +
                 "image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9\n";
+            String acceptTypeEdge="text/html,application/xhtml+xml,application/xml;q=0.9," +
+                "image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9";
 
             SparkTestUtil.UrlResponse response = http.doMethod("GET",HELLO, "", false, acceptTypeIE, requestHeader);
             assertEquals(200, response.status);
@@ -54,6 +57,11 @@ public class Issue688Test {
             response = http.doMethod("GET",HELLO, "", false, acceptTypeChrome, requestHeader);
             assertEquals(200, response.status);
             assertEquals("Specific", response.body);
+
+            response = http.doMethod("GET",HELLO, "", false, acceptTypeEdge, requestHeader);
+            assertEquals(200, response.status);
+            assertEquals("Specific", response.body);
+
 
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Try to fix #688 


When IE broswer visit spark, there are some problems. It is because IE will not contains q in AcceptType. So the chosen route doesn't fit the design documentation as follows. 

So I change the acceptType when I think it is from IE.
