### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 12.0.0.beta0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>12.0.0.beta0</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.48.v20220622
- [CVE-2023-26049](https://www.oscs1024.com/hd/CVE-2023-26049)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.48.v20220622 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS