### PR TITLE
Fix a flaky test testQueryParams

### DIFF
--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -468,7 +468,7 @@ public class RequestTest {
     @Test
     public void testQueryParams() {
 
-        Map<String, String[]> params = new HashMap<>();
+        Map<String, String[]> params = new LinkedHashMap<>();
         params.put("sort", new String[]{"asc"});
         params.put("items", new String[]{"10"});
 


### PR DESCRIPTION
This PR is to fix a flaky test `spark.RequestTest#testQueryParams`, we found it when using the latest version of spark:

1. To reproduce test failures:
- Run the following cmds:
```
 mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=spark.RequestTest#testQueryParams -DnondexRuns=10
```
- And then we'll get the following failures:
```
RequestTest.testQueryParams:479 Should return the query parameter names: arrays first differed at element [0]; expected:<[items]> but was:<[sort]>
```
2. Why it fails:
Line 471 `Map<String, String[]> params = new HashMap<>();` of`src/test/java/spark/RequestTest.java` defines a `HashMap`, which makes no guarantee about the iteration order. The [specification](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html) about HashMap says that "This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time".
3. Fix it:
By changing `HashMap` into `LinkedHashMap`.